### PR TITLE
fix(purge-rest-cache): cannot purge with redis

### DIFF
--- a/docs/samples/config/plugins.redis.js
+++ b/docs/samples/config/plugins.redis.js
@@ -17,6 +17,8 @@ module.exports = {
         },
       },
       strategy: {
+        // if you are using keyPrefix for your Redis, please add <keysPrefix>
+        keysPrefix: '<redis_keyPrefix>',
         contentTypes: [
           // list of Content-Types UID to cache
           "api::category.category",

--- a/packages/strapi-plugin-rest-cache/server/services/cacheStore.js
+++ b/packages/strapi-plugin-rest-cache/server/services/cacheStore.js
@@ -24,8 +24,8 @@ module.exports = ({ strapi }) => {
   let initialized = false;
 
   const pluginConfig = strapi.config.get('plugin.rest-cache');
-  const { getTimeout = 500 } = pluginConfig.provider;
-  const { keysPrefix = '' } = pluginConfig.strategy;
+  const { getTimeout } = pluginConfig.provider;
+  const { keysPrefix } = pluginConfig.strategy;
   const keysPrefixRe = keysPrefix ? new RegExp(`^${keysPrefix}`) : null;
 
   return {
@@ -108,7 +108,7 @@ module.exports = ({ strapi }) => {
 
       try {
         debug(`${chalk.redBright('[PURGING KEY]')}: ${key}`);
-        return provider.del(`${keysPrefix}${key}`);
+        return provider.del(key)
       } catch (error) {
         strapi.log.error(`REST Cache provider errored:`);
         strapi.log.error(error);
@@ -134,7 +134,7 @@ module.exports = ({ strapi }) => {
           }
 
           return keys
-            .filter((key) => keysPrefixRe.match(key))
+            .filter((key) => keysPrefixRe.test(key))
             .map((key) => key.replace(keysPrefixRe, ''));
         });
       } catch (error) {
@@ -184,7 +184,7 @@ module.exports = ({ strapi }) => {
       /**
        * @param {string} key
        */
-      const shouldDel = (key) => regExps.find((r) => r.test(key));
+      const shouldDel = (key) => regExps.find((r) => r.test(key.replace(keysPrefix, '')));
 
       /**
        * @param {string} key


### PR DESCRIPTION
Hello everyone, I'm getting same issue with these issues on my production.

1. https://github.com/strapi-community/strapi-plugin-rest-cache/issues/11 
2. https://github.com/strapi-community/strapi-plugin-rest-cache/issues/2

It means, i'm using Redis to cache and while clicking on the "Purge REST Cache" button then it doesn't work.

After debugging then i see the cause is the `shouldDel` at https://github.com/strapi-community/strapi-plugin-rest-cache/blob/e37ca174a7bb10c543edadbc12c0f8c52ed1f6cb/packages/strapi-plugin-rest-cache/server/services/cacheStore.js#L187 always returns an empty array so that we can't purge. What we expect that it returns an array with expected keys will be deleted.

Another issue, i'm using `keyPrefix` for my Redis and `shouldDel` compared with the key without `keyPrefix`.  

Thank you.