### PR TITLE
Fix del function in cacheStore.js, causes cache key not purged properly

### DIFF
--- a/packages/strapi-plugin-rest-cache/server/services/cacheStore.js
+++ b/packages/strapi-plugin-rest-cache/server/services/cacheStore.js
@@ -107,8 +107,8 @@ function createCacheStoreService({ strapi }) {
       }
 
       try {
-        debug(`${chalk.redBright('[PURGING KEY]')}: ${key}`);
-        return provider.del(key);
+        debug(`${chalk.redBright('[PURGING KEY]')}: ${keysPrefix}${key}`);
+        return provider.del(`${keysPrefix}${key}`);
       } catch (error) {
         strapi.log.error(`REST Cache provider errored:`);
         strapi.log.error(error);

--- a/packages/strapi-plugin-rest-cache/server/services/cacheStore.js
+++ b/packages/strapi-plugin-rest-cache/server/services/cacheStore.js
@@ -107,7 +107,7 @@ function createCacheStoreService({ strapi }) {
       }
 
       try {
-        debug(`${chalk.redBright('[PURGING KEY]')}: ${keysPrefix}${key}`);
+        debug(`${chalk.redBright('[PURGING KEY]')}: ${key}`);
         return provider.del(`${keysPrefix}${key}`);
       } catch (error) {
         strapi.log.error(`REST Cache provider errored:`);


### PR DESCRIPTION
Cache `key` in `del` function has no `keysPrefix`, it causes the cache `key` would never be purged.