### PR TITLE
Transform data before storing in cache

### DIFF
--- a/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
+++ b/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
@@ -118,13 +118,15 @@ function createRecv(options, { strapi }) {
           );
         });
       }
-      let data = ctx.body
-      const transformer = strapi.service('plugin::transformer.transformService')
+      let data = ctx.body;
+      const transformer = strapi.service(
+        'plugin::transformer.transformService'
+      );
 
       // Transformer plugin is installed, transform data before storing in cache
       if (transformer) {
         const transformerConfig = strapi.config.get('plugin.transformer');
-        data = transformer.response(transformerConfig, ctx.body)
+        data = transformer.response(transformerConfig, ctx.body);
       }
       // persist cache asynchronously
       store.set(cacheKey, data, maxAge).catch(() => {

--- a/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
+++ b/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
@@ -118,9 +118,16 @@ function createRecv(options, { strapi }) {
           );
         });
       }
+      let data = ctx.body
+      const transformer = strapi.service('plugin::transformer.transformService')
 
+      // Transformer plugin is installed, transform data before storing in cache
+      if (transformer) {
+        const transformerConfig = strapi.config.get('plugin.transformer');
+        data = transformer.response(transformerConfig, ctx.body)
+      }
       // persist cache asynchronously
-      store.set(cacheKey, ctx.body, maxAge).catch(() => {
+      store.set(cacheKey, data, maxAge).catch(() => {
         debug(
           `[RECV] GET ${cacheKey} ${chalk.yellow(
             'Unable to store Content in cache'


### PR DESCRIPTION
This PR adds a check if the `strapi-plugin-transformer` plugin is installed. If it is, it should transform the data before storing into the cache provider.

This relates to #25, and seems to solve the issue afaik