### PR TITLE
Add support for Strapi REST API Prefix

### DIFF
--- a/packages/strapi-plugin-rest-cache/server/utils/config/resolveUserStrategy.js
+++ b/packages/strapi-plugin-rest-cache/server/utils/config/resolveUserStrategy.js
@@ -123,10 +123,13 @@ function resolveUserStrategy(strapi, userOptions) {
       continue;
     }
 
+    // get strapi api prefix
+    const apiPrefix = strapi.config.get('api.rest.prefix');
+
     // https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest-api.html#api-endpoints
     // https://github.com/strapi/strapi/blob/master/packages/core/strapi/lib/core-api/routes/index.js
     if (cacheConfig.singleType) {
-      const base = `/api/${contentType.info.singularName}`;
+      const base = `${apiPrefix}/${contentType.info.singularName}`;
 
       // delete
       cacheConfig.routes.push(
@@ -155,7 +158,7 @@ function resolveUserStrategy(strapi, userOptions) {
         })
       );
     } else {
-      const base = `/api/${contentType.info.pluralName}`;
+      const base = `${apiPrefix}/${contentType.info.pluralName}`;
 
       // create
       cacheConfig.routes.push(


### PR DESCRIPTION
## What it does

- [x] Adds support the native Strapi API Prefix on the REST API: https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/api.html

## How to test it

In your ./config/api.js set the API Prefix to anything other than `/api` (which is the default:

```js
module.exports = ({ env }) => ({
  rest: {
    prefix: env('API_PREFIX', '/v1'),
    defaultLimit: env('API_DEFAULT_LIMIT', 25),
    maxLimit: env('API_MAX_LIMIT', 100),
    withCount: env('API_WITH_COUNT', true),
  },
});
```

And check that the content-types are still cached compared to before this PR where if the prefix is not set to `/api` then nothing will be cached.