### PR TITLE
fix(recv): remove transformer plugin

### DIFF
--- a/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
+++ b/packages/strapi-plugin-rest-cache/server/middlewares/recv.js
@@ -118,18 +118,9 @@ function createRecv(options, { strapi }) {
           );
         });
       }
-      let data = ctx.body;
-      const transformer = strapi.service(
-        'plugin::transformer.transformService'
-      );
 
-      // Transformer plugin is installed, transform data before storing in cache
-      if (transformer) {
-        const transformerConfig = strapi.config.get('plugin.transformer');
-        data = transformer.response(transformerConfig, ctx.body);
-      }
       // persist cache asynchronously
-      store.set(cacheKey, data, maxAge).catch(() => {
+      store.set(cacheKey, ctx.body, maxAge).catch(() => {
         debug(
           `[RECV] GET ${cacheKey} ${chalk.yellow(
             'Unable to store Content in cache'


### PR DESCRIPTION
As of v3 of the transformer plugin this is no longer required and will break the rest-cache plugin if left in due to API changes.

Basically reverts the changes done in #35