### PR TITLE
fix: remove trailing slashes from cache keys

### DIFF
--- a/packages/strapi-plugin-rest-cache/server/utils/keys/generateCacheKey.js
+++ b/packages/strapi-plugin-rest-cache/server/utils/keys/generateCacheKey.js
@@ -21,7 +21,10 @@ function generateCacheKey(
     headersSuffix = generateHeadersKey(ctx, keys.useHeaders);
   }
 
-  return `${ctx.request.path}?${querySuffix}&${headersSuffix}`;
+  // standardize url paths by removing trailing slashes
+  const requestPath = ctx.request.path.replace(/\/$/, '');
+
+  return `${requestPath}?${querySuffix}&${headersSuffix}`;
 }
 
 module.exports = { generateCacheKey };


### PR DESCRIPTION
Fix for https://github.com/strapi-community/strapi-plugin-rest-cache/issues/45.  

This change removes trailing slashes from cache keys.

Requested url is used as key for the cache. But the same request with and without a trailing slash lead to 2 separate cache entries.

This also caused issues with purging and clearByUid (only the entry without the trailing slash was removed).