### PR TITLE
fix: cache-manager require time to live in millis

### DIFF
--- a/packages/strapi-provider-rest-cache-couchbase/lib/CouchbaseCacheProvider.js
+++ b/packages/strapi-provider-rest-cache-couchbase/lib/CouchbaseCacheProvider.js
@@ -27,7 +27,7 @@ class CouchbaseCacheProvider extends CacheProvider {
    */
   async set(key, val, maxAge = 3600) {
     const options = {
-      ttl: maxAge / 1000,
+      ttl: maxAge * 1000,
     };
     return this.cache.set(key, val, options);
   }

--- a/packages/strapi-provider-rest-cache-memory/lib/MemoryCacheProvider.js
+++ b/packages/strapi-provider-rest-cache-memory/lib/MemoryCacheProvider.js
@@ -24,7 +24,7 @@ class MemoryCacheProvider extends CacheProvider {
    */
   async set(key, val, maxAge = 3600) {
     const options = {
-      ttl: maxAge / 1000,
+      ttl: maxAge * 1000,
     };
     return this.cache.set(key, val, options);
   }

--- a/packages/strapi-provider-rest-cache-redis/lib/RedisCacheProvider.js
+++ b/packages/strapi-provider-rest-cache-redis/lib/RedisCacheProvider.js
@@ -29,7 +29,7 @@ class RedisCacheProvider extends CacheProvider {
    */
   async set(key, val, maxAge = 3600) {
     const options = {
-      ttl: maxAge / 1000,
+      ttl: maxAge * 1000,
     };
     return this.cache.set(key, val, options);
   }


### PR DESCRIPTION
The library cache-manager requires the field ttl in millis.
we are dividing seconds in 1000 but instead we need to multiply.

Please close this PR if you feel I am wrong.


PS: if you go to the doc it says this:
https://github.com/node-cache-manager/node-cache-manager/blob/a9703b100a3136713d948d85c0056cf3b0db8687/README.md?plain=1#L32

Thanks.

---

fixes https://github.com/strapi-community/strapi-plugin-rest-cache/issues/53 (maybe)