### PR TITLE
Return immediately if client is ready

### DIFF
--- a/packages/strapi-provider-rest-cache-redis/lib/index.js
+++ b/packages/strapi-provider-rest-cache-redis/lib/index.js
@@ -23,6 +23,10 @@ function waitForRedis(client) {
       );
     };
 
+    if (client.status === "ready") {
+       return onReady();
+    }
+
     client.once("ready", onReady);
     client.once("error", onError);
   });


### PR DESCRIPTION
No need to wait for redis to emit "ready" if the client connection is already ready. This prevents the function to forever hang awaiting for a ready command from an already ready client.