### PR TITLE
fix(rest-cache): improve module loading and error handling #118

### DIFF
--- a/packages/plugin-rest-cache/server/src/bootstrap.js
+++ b/packages/plugin-rest-cache/server/src/bootstrap.js
@@ -36,8 +36,11 @@ const createProvider = async (providerConfig, { strapi }) => {
     const requireProvider = createRequire(import.meta.url);
     provider = requireProvider(modulePath);
   } catch (err) {
+    const details = err?.message
+      ? `\nTried to load: ${modulePath}\nCause: ${err.message}`
+      : `\nTried to load: ${modulePath}`;
     throw new Error(
-      `Could not load REST Cache provider "${providerName}". You may need to install a provider plugin "yarn add @strapi-community/provider-rest-cache-${providerName}".`
+      `Could not load REST Cache provider "${providerName}". You may need to install a provider plugin "yarn add @strapi-community/provider-rest-cache-${providerName}".${details}`
     );
   }
 

--- a/packages/provider-rest-cache-memory/lib/MemoryCacheProvider.js
+++ b/packages/provider-rest-cache-memory/lib/MemoryCacheProvider.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const Keyv = require('keyv').default;
-const QuickLRU = require('quick-lru');
+const keyvModule = require('keyv');
+const Keyv = keyvModule.default ?? keyvModule;
+const quickLruModule = require('quick-lru');
+const QuickLRU = quickLruModule.default ?? quickLruModule;
 const { createCache } = require('cache-manager');
 const { CacheProvider } = require('@strapi-community/plugin-rest-cache/types');
 
@@ -20,7 +22,7 @@ class MemoryCacheProvider extends CacheProvider {
       ttl,
       stores: [
         new Keyv({
-          store: new QuickLRU.default(adapterOptions),
+          store: new QuickLRU(adapterOptions),
         }),
       ],
     });

--- a/packages/provider-rest-cache-memory/package.json
+++ b/packages/provider-rest-cache-memory/package.json
@@ -73,6 +73,7 @@
   },
   "dependencies": {
     "cache-manager": "^7.1.1",
+    "keyv": "^5.5.0",
     "quick-lru": "7.0.1"
   },
   "devDependencies": {

--- a/packages/provider-rest-cache-redis/lib/RedisCacheProvider.js
+++ b/packages/provider-rest-cache-redis/lib/RedisCacheProvider.js
@@ -1,8 +1,10 @@
 'use strict';
 
 const { createCache } = require('cache-manager');
-const Keyv = require('keyv').default;
-const KeyvRedis = require('@keyv/redis');
+const keyvModule = require('keyv');
+const Keyv = keyvModule.default ?? keyvModule;
+const keyvRedisModule = require('@keyv/redis');
+const KeyvRedis = keyvRedisModule.default ?? keyvRedisModule;
 const { CacheProvider } = require('@strapi-community/plugin-rest-cache/types');
 
 class RedisCacheProvider extends CacheProvider {
@@ -16,7 +18,7 @@ class RedisCacheProvider extends CacheProvider {
       ttl,
       stores: [
         new Keyv({
-          store: new KeyvRedis.default(client, adapterOptions),
+          store: new KeyvRedis(client, adapterOptions),
         }),
       ],
     });

--- a/packages/provider-rest-cache-redis/package.json
+++ b/packages/provider-rest-cache-redis/package.json
@@ -73,7 +73,8 @@
   },
   "dependencies": {
     "@keyv/redis": "^3.0.1",
-    "cache-manager": "^7.1.1"
+    "cache-manager": "^7.1.1",
+    "keyv": "^5.5.0"
   },
   "devDependencies": {
     "@strapi-community/plugin-redis": "^2.0.0",


### PR DESCRIPTION
Issue #118 

## Root Cause
- The memory/redis provider packages require `keyv` at runtime but do not declare it as a dependency. In many local/monorepo installs `keyv` is accidentally present via hoisting/resolutions, but in production (or a clean install) it’s missing, so `require('keyv')` fails and the main plugin reports the generic “Could not load REST Cache provider \"memory\"” error.
- Additionally, the providers currently assume ESM-style default exports (`require('keyv').default`, `new QuickLRU.default(...)`, `new KeyvRedis.default(...)`). Depending on which version/module-shape is installed, this can produce `TypeError: Keyv is not a constructor` (Node 22 reports in the issue).


## Code Changes
- Add `keyv` as a direct dependency of:
 - `@strapi-community/provider-rest-cache-memory`
 - `@strapi-community/provider-rest-cache-redis`
- Make the providers resilient to both CJS and ESM module shapes by switching to “default-or-module” resolution:
 - `const keyvModule = require('keyv'); const Keyv = keyvModule.default ?? keyvModule;`
 - `const quickLruModule = require('quick-lru'); const QuickLRU = quickLruModule.default ?? quickLruModule;`
 - `const keyvRedisModule = require('@keyv/redis'); const KeyvRedis = keyvRedisModule.default ?? keyvRedisModule;`
 - Update the constructors to use `new QuickLRU(...)` and `new KeyvRedis(...)` accordingly.
- Improve the provider loader error to include the underlying failure reason (missing dependency / ESM interop), so users don’t get misled into repeatedly reinstalling the provider package.


## Verification
- Validate a clean install scenario:
 - Install only `@strapi-community/plugin-rest-cache` in a fresh Strapi 5 app and start it with provider `memory`.
- Validate Node runtime behavior:
 - Start the memory playground under Node 20 and Node 22; ensure no “provider cannot load” and no “Keyv is not a constructor”.
- Smoke-test redis provider load (module import + initialization), ensuring the same interop fixes apply.


## Deliverables
- Patch to provider package.json files (adds missing dependency).
- Patch to provider runtime code (robust imports for Node 20/22).
- Better runtime error message when a provider fails to load.
