### PR TITLE
Fix: Correct admin client URLs to match Strapi 5 routes and fix 404s

### DIFF
--- a/packages/plugin-rest-cache/admin/src/components/PurgeCacheButton/index.jsx
+++ b/packages/plugin-rest-cache/admin/src/components/PurgeCacheButton/index.jsx
@@ -36,7 +36,7 @@ function PurgeCacheButton({ contentType, params, wildcard = undefined, fullWidth
       // Show the loading state
       setIsModalConfirmButtonLoading(true);
 
-      await post(`/${pluginId}/purge`, {
+      await post(`/admin/${pluginId}/purge`, {
         contentType,
         params,
         wildcard,

--- a/packages/plugin-rest-cache/admin/src/components/PurgeDocumentAction/index.jsx
+++ b/packages/plugin-rest-cache/admin/src/components/PurgeDocumentAction/index.jsx
@@ -60,7 +60,7 @@ function PurgeDocumentAction({
               'Are you sure you want to purge REST Cache for this entry?',
           })}</>,
         onConfirm: async () => {
-          await post(`/${pluginId}/purge`, {
+          await post(`/admin/${pluginId}/purge`, {
             contentType: model,
             params,
             wildcard: isSingleType,

--- a/packages/plugin-rest-cache/admin/src/hooks/useCacheStrategy/index.js
+++ b/packages/plugin-rest-cache/admin/src/hooks/useCacheStrategy/index.js
@@ -34,7 +34,7 @@ const useCacheStrategy = (shouldFetchData = true) => {
         type: 'GET_DATA',
       });
 
-      const {data} = await get(`/${pluginId}/config/strategy`, {
+      const {data} = await get(`/admin/${pluginId}/config/strategy`, {
         signal,
       });
       const strategy = data.strategy


### PR DESCRIPTION
### Summary
This PR updates the plugin’s admin client URLs to match the updated route structure introduced in Strapi 5. In Strapi 5, admin‑related endpoints were moved under the /admin namespace, but the plugin’s client-side code was still calling the older, pre‑Strapi 5 paths. This mismatch caused persistent 404 errors in the Admin console.

### What’s Changed

- Updated the admin-side requests to use the correct Strapi 5 URLs for:

    - Cache strategy endpoint
    - Cache purge endpoint(s)

- No changes were made to server routes — this PR updates only the plugin’s client code to align with Strapi 5.
```
/admin/rest-cache/config/strategy
/admin/rest-cache/purge
```
