### PR TITLE
fix: correct 1000x cache TTL inflation and purge on all admin write routes

### DIFF
--- a/packages/plugin-rest-cache/server/src/services/cacheStore.js
+++ b/packages/plugin-rest-cache/server/src/services/cacheStore.js
@@ -68,9 +68,9 @@ export default function createCacheStoreService({ strapi }) {
     /**
      * @param {string} key
      * @param {any} val
-     * @param {number=} maxAge
+     * @param {number=} maxAge in milliseconds
      */
-    async set(key, val, maxAge = 3600) {
+    async set(key, val, maxAge = 3600000) {
       if (!initialized) {
         strapi.log.error('REST Cache provider not initialized');
         return null;

--- a/packages/plugin-rest-cache/server/src/types/CacheContentTypeConfig.js
+++ b/packages/plugin-rest-cache/server/src/types/CacheContentTypeConfig.js
@@ -48,7 +48,7 @@ export class CacheContentTypeConfig {
     const {
       singleType = false,
       injectDefaultRoutes = true,
-      maxAge = true,
+      maxAge = 3600000,
       hitpass = false,
       keys = new CacheKeysConfig(),
       routes = [],

--- a/packages/plugin-rest-cache/server/src/types/CacheProvider.js
+++ b/packages/plugin-rest-cache/server/src/types/CacheProvider.js
@@ -25,9 +25,9 @@ export class CacheProvider {
   /**
    * @param {string} key
    * @param {any} val
-   * @param {number=} maxAge
+   * @param {number=} maxAge in milliseconds
    */
-  async set(key, val, maxAge = 3600) {
+  async set(key, val, maxAge = 3600000) {
     throw new Error("Method 'set()' must be implemented.");
   }
 

--- a/packages/plugin-rest-cache/server/src/utils/middlewares/injectMiddlewares.js
+++ b/packages/plugin-rest-cache/server/src/utils/middlewares/injectMiddlewares.js
@@ -4,14 +4,26 @@ import chalk from 'chalk';
 import debug from 'debug';
 import { flattenRoutes } from './flattenRoutes';
 
+// Content-manager routes that mutate content and therefore must purge the cache.
+// Keep in sync with packages/core/content-manager/server/src/routes/admin.ts in
+// strapi/strapi. Note that `/collection-types/:model/actions/bulkFindForValidation`
+// is deliberately absent: despite being a POST it is a read operation, so purging
+// on it would cause spurious cache flushes.
 const adminRoutes = {
   post: [
     '/single-types/:model/actions/publish',
     '/single-types/:model/actions/unpublish',
+    '/single-types/:model/actions/discard',
     '/collection-types/:model',
+    '/collection-types/:model/clone/:sourceId',
+    '/collection-types/:model/auto-clone/:sourceId',
+    '/collection-types/:model/actions/publish',
     '/collection-types/:model/:id/actions/publish',
     '/collection-types/:model/:id/actions/unpublish',
+    '/collection-types/:model/:id/actions/discard',
     '/collection-types/:model/actions/bulkDelete',
+    '/collection-types/:model/actions/bulkPublish',
+    '/collection-types/:model/actions/bulkUnpublish',
   ],
   put: ['/single-types/:model', '/collection-types/:model/:id'],
   delete: ['/single-types/:model', '/collection-types/:model/:id'],

--- a/packages/provider-rest-cache-memory/lib/MemoryCacheProvider.js
+++ b/packages/provider-rest-cache-memory/lib/MemoryCacheProvider.js
@@ -36,10 +36,12 @@ class MemoryCacheProvider extends CacheProvider {
   /**
    * @param {string} key
    * @param {any} val
-   * @param {number=} maxAge
+   * @param {number=} maxAge in milliseconds
    */
-  async set(key, val, maxAge = 3600) {
-    return this.cache.set(key, val, maxAge * 1000);
+  async set(key, val, maxAge = 3600000) {
+    // cache-manager's set() takes a ttl in milliseconds and maxAge is already
+    // in milliseconds - do not convert.
+    return this.cache.set(key, val, maxAge);
   }
 
   /**

--- a/packages/provider-rest-cache-redis/lib/RedisCacheProvider.js
+++ b/packages/provider-rest-cache-redis/lib/RedisCacheProvider.js
@@ -32,10 +32,12 @@ class RedisCacheProvider extends CacheProvider {
   /**
    * @param {string} key
    * @param {any} val
-   * @param {number=} maxAge
+   * @param {number=} maxAge in milliseconds
    */
-  async set(key, val, maxAge = 3600) {
-    return this.cache.set(key, val, maxAge * 1000);
+  async set(key, val, maxAge = 3600000) {
+    // cache-manager's set() takes a ttl in milliseconds and maxAge is already
+    // in milliseconds - do not convert.
+    return this.cache.set(key, val, maxAge);
   }
 
   /**

--- a/shared/tests/cache-ttl.test.js
+++ b/shared/tests/cache-ttl.test.js
@@ -1,0 +1,56 @@
+"use strict";
+
+/**
+ * Coverage for cache entry expiry.
+ *
+ * `maxAge` is milliseconds throughout the plugin (the documented default is
+ * 3600000 = 1 hour). A cached entry must therefore expire `maxAge` milliseconds
+ * after it is stored.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/126
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(60000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const MAX_AGE_MS = 2000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("cache ttl", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    // shared/config/cache-strategy.js reads the default maxAge from this var
+    process.env.ENABLE_MAX_AGE = String(MAX_AGE_MS);
+    await setup();
+  });
+  afterAll(async () => {
+    delete process.env.ENABLE_MAX_AGE;
+    await teardown();
+  });
+
+  beforeEach(() => strapi.plugin("rest-cache").service("cacheStore").reset());
+
+  it("serves from cache before maxAge elapses", async () => {
+    await agent().get("/api/homepage");
+    await sleep(MAX_AGE_MS / 4);
+    const second = await agent().get("/api/homepage");
+
+    expect(second.get("x-cache")).toBe("HIT");
+  });
+
+  it("expires the entry once maxAge has elapsed", async () => {
+    const first = await agent().get("/api/homepage");
+    expect(first.get("x-cache")).toBe("MISS");
+
+    await sleep(MAX_AGE_MS * 1.5);
+
+    const second = await agent().get("/api/homepage");
+    expect(second.get("x-cache")).toBe("MISS");
+  });
+});

--- a/shared/tests/collection-type-admin-purge.test.js
+++ b/shared/tests/collection-type-admin-purge.test.js
@@ -1,0 +1,142 @@
+"use strict";
+
+/**
+ * Coverage for admin content-manager actions that mutate content and therefore
+ * must purge the REST cache.
+ *
+ * The plugin injects its `purgeAdmin` middleware onto a hardcoded list of
+ * content-manager routes (server/src/utils/middlewares/injectMiddlewares.js).
+ * Any write route missing from that list silently leaves stale content in the
+ * cache. See https://github.com/strapi-community/plugin-rest-cache/issues/127
+ */
+
+const { setup, teardown, agent, adminAgent } = require("./helpers/strapi");
+
+jest.setTimeout(60000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const UID = "api::article.article";
+const CM = `/content-manager/collection-types/${UID}`;
+
+/** Warm the cache for the article list and assert we got there. */
+async function warmArticleCache() {
+  const first = await agent().get("/api/articles");
+  const second = await agent().get("/api/articles");
+
+  expect(first.get("x-cache")).toBe("MISS");
+  expect(second.get("x-cache")).toBe("HIT");
+}
+
+/** Read documents straight from the document service, bypassing the cache. */
+function findArticles(status = "published") {
+  return strapi.documents(UID).findMany({ status });
+}
+
+describe("admin content-manager purge", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => strapi.plugin("rest-cache").service("cacheStore").reset());
+
+  it("purges when an entry is published", async () => {
+    const [draft] = await strapi
+      .documents(UID)
+      .findMany({ status: "draft", limit: 1 });
+
+    await warmArticleCache();
+
+    const res = await adminAgent().post(
+      `${CM}/${draft.documentId}/actions/publish`
+    );
+    expect(res.status).toBe(200);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when an entry is unpublished", async () => {
+    const [published] = await findArticles();
+
+    await warmArticleCache();
+
+    const res = await adminAgent().post(
+      `${CM}/${published.documentId}/actions/unpublish`
+    );
+    expect(res.status).toBe(200);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when entries are bulk published", async () => {
+    const drafts = await strapi
+      .documents(UID)
+      .findMany({ status: "draft", limit: 2 });
+    const documentIds = drafts.map((d) => d.documentId);
+
+    await warmArticleCache();
+
+    const res = await adminAgent()
+      .post(`${CM}/actions/bulkPublish`)
+      .send({ documentIds });
+    expect(res.status).toBe(200);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when entries are bulk unpublished", async () => {
+    const published = await findArticles();
+    const documentIds = published.slice(0, 2).map((d) => d.documentId);
+
+    await warmArticleCache();
+
+    const res = await adminAgent()
+      .post(`${CM}/actions/bulkUnpublish`)
+      .send({ documentIds });
+    expect(res.status).toBe(200);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when an entry is cloned", async () => {
+    const [source] = await findArticles();
+
+    await warmArticleCache();
+
+    const res = await adminAgent()
+      .post(`${CM}/clone/${source.documentId}`)
+      .send({ title: "Cloned article", slug: "cloned-article" });
+    expect(res.status).toBe(200);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when a draft is discarded", async () => {
+    const [published] = await findArticles();
+
+    // Create an unpublished edit so there is a draft to discard.
+    await strapi.documents(UID).update({
+      documentId: published.documentId,
+      data: { title: "Edited but not published" },
+    });
+
+    await warmArticleCache();
+
+    const res = await adminAgent().post(
+      `${CM}/${published.documentId}/actions/discard`
+    );
+    expect(res.status).toBe(200);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+});


### PR DESCRIPTION
Stacked on #135 — review that one first. Base is `chore/test-playground-foundation`; retarget to `main` once #135 merges.

Fixes two bugs that are shipping today. Both were pinned by a test that was **verified to fail first**, then fixed.

## Fixes #126 — cache TTL was 1000× longer than configured

`maxAge` is milliseconds throughout the plugin (documented default `3600000` = 1 hour) and `recv.js:121` passes it straight through. Both providers then multiplied by 1000 again before handing it to cache-manager, whose `set()` takes **milliseconds**.

The default 1 hour became **41.7 days**. Entries effectively never expired — the cause of the Redis memory exhaustion reported in #124.

Also reconciled the `maxAge` default, which disagreed in four places (`3600`, `true`, `3600000`). `CacheContentTypeConfig` defaulted it to the boolean `true` — reachable through the public `./types` export and yielding a **1 second** TTL.

## Fixes #127 — admin bulk publish/unpublish, discard and clone left stale cache

`injectMiddlewares.js` hardcodes which content-manager routes get the `purgeAdmin` middleware, and was missing 7 content-mutating routes:

```
POST /single-types/:model/actions/discard
POST /collection-types/:model/clone/:sourceId
POST /collection-types/:model/auto-clone/:sourceId
POST /collection-types/:model/actions/publish
POST /collection-types/:model/:id/actions/discard
POST /collection-types/:model/actions/bulkPublish
POST /collection-types/:model/actions/bulkUnpublish
```

`bulkFindForValidation` is deliberately **not** added: despite being a POST it is a read guarded by `explorer.read`, so purging on it would cause spurious flushes.

These two bugs compounded — a missed purge meant stale content served for ~41 days rather than expiring in an hour.

## Tests

**`shared/tests/collection-type-admin-purge.test.js`** — one case per admin write action. The RED run was precisely diagnostic:

```
✓ purges when an entry is published          <- already in the list
✓ purges when an entry is unpublished        <- already in the list
✕ purges when entries are bulk published     Expected "MISS", Received "HIT"
✕ purges when entries are bulk unpublished   Expected "MISS", Received "HIT"
✕ purges when an entry is cloned             Expected "MISS", Received "HIT"
✕ purges when a draft is discarded           Expected "MISS", Received "HIT"
```

**`shared/tests/cache-ttl.test.js`** — asserts an entry survives before `maxAge` and expires after it. The expiry case failed before the fix (`Expected "MISS", Received "HIT"`).

Verified against **both** providers — 38/38 on memory and on redis against a real server, up from 30.

## Also

- CI Node matrix `[20, 22]` → `[20, 22, 24]`. Strapi 5.52.0 supports 20–26 and tests `[22, 24, 26]`, so the old matrix tested nothing Strapi itself covers.
- Root `engines.node` `">=14.0.0"` → `">=20.0.0 <=26.x.x"`.

## Not addressed here

The hardcoded route list stays a maintenance liability — it must be re-verified against Strapi core every release, and it cannot cover writes that never traverse an HTTP route (scheduled Content Releases, GraphQL mutations, direct `strapi.documents()` calls). #129 tracks moving invalidation to document service middleware, which deletes the list entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
