### PR TITLE
feat: document service invalidation, custom route fix, and content type/API name mismatch fix

### DIFF
--- a/packages/plugin-rest-cache/server/src/config/index.js
+++ b/packages/plugin-rest-cache/server/src/config/index.js
@@ -14,6 +14,12 @@ export default {
       enableEtag: false,
       enableXCacheHeaders: false,
       enableAdminCTBMiddleware: true,
+      // Invalidate from the document service instead of from HTTP route
+      // middleware. Catches writes that no route can see (GraphQL mutations,
+      // scheduled Content Releases, custom strapi.documents() calls) and
+      // cannot drift out of sync with Strapi's route list.
+      // Set to false to fall back to the legacy route-injection behaviour.
+      enableDocumentServiceMiddleware: true,
       resetOnStartup: false,
       clearRelatedCache: true,
       keysPrefix: '',

--- a/packages/plugin-rest-cache/server/src/register.js
+++ b/packages/plugin-rest-cache/server/src/register.js
@@ -7,6 +7,7 @@ import debug from 'debug';
 
 import { resolveUserStrategy } from './utils/config/resolveUserStrategy';
 import { injectMiddlewares } from './utils/middlewares/injectMiddlewares';
+import { registerDocumentServiceMiddleware } from './utils/middlewares/registerDocumentServiceMiddleware';
 
 /**
  * @param {{ strapi: Strapi }} strapi
@@ -30,6 +31,13 @@ export default async function register({ strapi }) {
 
   // boostrap cache middlewares
   injectMiddlewares(strapi, strategy);
+
+  // Invalidation. The document service hook supersedes the route-injected
+  // purge middlewares, so the two are mutually exclusive - running both would
+  // purge twice for every write that does go through a route.
+  if (strategy.enableDocumentServiceMiddleware) {
+    registerDocumentServiceMiddleware(strapi);
+  }
 
   if (strategy.resetOnStartup) {
     strapi.log.warn('Reset cache on startup is enabled');

--- a/packages/plugin-rest-cache/server/src/types/CachePluginStrategy.js
+++ b/packages/plugin-rest-cache/server/src/types/CachePluginStrategy.js
@@ -14,6 +14,8 @@ export class CachePluginStrategy {
 
   enableAdminCTBMiddleware = true;
 
+  enableDocumentServiceMiddleware = true;
+
   resetOnStartup = false;
 
   clearRelatedCache = false;
@@ -38,6 +40,7 @@ export class CachePluginStrategy {
       enableEtag = false,
       enableXCacheHeaders = false,
       enableAdminCTBMiddleware = true,
+      enableDocumentServiceMiddleware = true,
       resetOnStartup = false,
       clearRelatedCache = true,
       maxAge = 3600000,
@@ -50,6 +53,7 @@ export class CachePluginStrategy {
     this.enableEtag = enableEtag;
     this.enableXCacheHeaders = enableXCacheHeaders;
     this.enableAdminCTBMiddleware = enableAdminCTBMiddleware;
+    this.enableDocumentServiceMiddleware = enableDocumentServiceMiddleware;
     this.resetOnStartup = resetOnStartup;
     this.clearRelatedCache = clearRelatedCache;
     this.maxAge = maxAge;

--- a/packages/plugin-rest-cache/server/src/utils/config/resolveUserStrategy.js
+++ b/packages/plugin-rest-cache/server/src/utils/config/resolveUserStrategy.js
@@ -18,6 +18,18 @@ const routeParamNameRegex = /:([^/]+)/g;
 const routeParams = /(?<=\/\:).*?(?=\/|$)/g;
 
 /**
+ * Extract the API name from a content type uid.
+ *
+ * "api::writer.editor" -> "writer"
+ *
+ * @param {string} uid
+ * @return {string}
+ */
+function getApiNameFromUid(uid) {
+  return uid.split('::')[1]?.split('.')[0];
+}
+
+/**
  * @param {Strapi} strapi
  * @param {any} userOptions
  * @return {CachePluginStrategy}
@@ -128,9 +140,25 @@ export const resolveUserStrategy = function (strapi, userOptions) {
 
     // get strapi api prefix
     const apiPrefix = strapi.config.get('api.rest.prefix');
-    for (const routes of Object.values(
-      strapi.apis[contentType.info.singularName].routes
-    )) {
+
+    // Resolve the owning API from the uid rather than from the content type's
+    // singular name. A content type does not have to be named after the API it
+    // lives in - "api::writer.editor" is registered under strapi.apis.writer,
+    // not strapi.apis.editor - and using the singular name means such content
+    // types either resolve to the wrong API or, more often, crash the whole
+    // application at register time with "Cannot read properties of undefined".
+    // See https://github.com/strapi-community/plugin-rest-cache/issues/125
+    const apiName = getApiNameFromUid(cacheConfig.contentType);
+    const api = strapi.apis[apiName];
+
+    if (!api) {
+      throw new Error(
+        `Unable to resolve rest-cache options: no API "${apiName}" found for contentType "${cacheConfig.contentType}". ` +
+          `Set "injectDefaultRoutes: false" for this contentType if it has no default routes.`
+      );
+    }
+
+    for (const routes of Object.values(api.routes)) {
       for (const route of routes.routes) {
         // @TODO remove path and method and use the one
         if (cacheConfig.singleType === true) {

--- a/packages/plugin-rest-cache/server/src/utils/middlewares/injectMiddlewares.js
+++ b/packages/plugin-rest-cache/server/src/utils/middlewares/injectMiddlewares.js
@@ -67,6 +67,11 @@ function injectMiddleware(route, pluginUUid, config = {}) {
 export const injectMiddlewares = function (strapi, strategy) {
   const strapiRoutes = flattenRoutes(strapi);
 
+  // When invalidation runs off the document service it already covers every
+  // write, including those that never reach a route. Injecting the route purge
+  // middlewares as well would purge twice for every routed write.
+  const purgeViaDocumentService = Boolean(strategy.enableDocumentServiceMiddleware);
+
   for (const cacheConf of strategy.contentTypes) {
     debug('strapi:plugin-rest-cache')(`[REGISTER] ${chalk.cyan(cacheConf.contentType)} routes middlewares`);
     for (const cacheRoute of cacheConf.routes) {
@@ -91,6 +96,9 @@ export const injectMiddlewares = function (strapi, strategy) {
           case 'PUT':
           case 'PATCH':
           case 'POST':
+            if (purgeViaDocumentService) {
+              break;
+            }
             debug('strapi:plugin-rest-cache')(
               `[REGISTER] ${cacheRoute.method} ${
                 cacheRoute.path
@@ -128,7 +136,9 @@ export const injectMiddlewares = function (strapi, strategy) {
     }
   }
   // --- Admin REST endpoints
-  if (strategy.enableAdminCTBMiddleware) {
+  // Superseded by the document service middleware, which sees content-manager
+  // writes (and bulk actions, clones and discards) without needing this list.
+  if (strategy.enableAdminCTBMiddleware && !purgeViaDocumentService) {
     debug('strapi:plugin-rest-cache')(`[REGISTER] ${chalk.magentaBright('admin')} routes middlewares`);
     let contentMangerRoutes = [];
     for (const routes of Object.values(

--- a/packages/plugin-rest-cache/server/src/utils/middlewares/injectMiddlewares.js
+++ b/packages/plugin-rest-cache/server/src/utils/middlewares/injectMiddlewares.js
@@ -29,6 +29,17 @@ const adminRoutes = {
   delete: ['/single-types/:model', '/collection-types/:model/:id'],
 };
 
+/**
+ * Strip the trailing "+" repeatable-param marker so a configured route path and
+ * the path Strapi registered compare equal.
+ *
+ * @param {string} path
+ * @return {string}
+ */
+function normalizeRoutePath(path) {
+  return (path || '').replace(/\+$/, '');
+}
+
 function injectMiddleware(route, pluginUUid, config = {}) {
   if (typeof route.config === 'undefined') {
     route.config = {};
@@ -79,8 +90,12 @@ export const injectMiddlewares = function (strapi, strategy) {
         (route) =>
           // You can modify this to search for a specific route or multiple
           route.method === cacheRoute.method &&
-          //below replace removes the + at the end of the line
-          route.globalPath === cacheRoute.path.replace(/\+$/, '')
+          // Normalise both sides: a trailing "+" marks a repeatable param
+          // (e.g. "/categories/slug/:slug+") and is part of the registered
+          // path as well as the configured one. Stripping it from only one
+          // side means such routes never match, and are silently left
+          // uncached.
+          normalizeRoutePath(route.globalPath) === normalizeRoutePath(cacheRoute.path)
       );
 
       // If the route exists lets inject the middleware

--- a/packages/plugin-rest-cache/server/src/utils/middlewares/registerDocumentServiceMiddleware.js
+++ b/packages/plugin-rest-cache/server/src/utils/middlewares/registerDocumentServiceMiddleware.js
@@ -1,0 +1,106 @@
+'use strict';
+
+import chalk from 'chalk';
+import debug from 'debug';
+
+/**
+ * Document service actions that change content and must therefore invalidate
+ * the cache. The middleware also runs for reads (findMany, findOne, count...),
+ * so this filter is mandatory - without it every cache hit would immediately
+ * invalidate itself.
+ */
+const WRITE_ACTIONS = new Set([
+  'create',
+  'clone',
+  'update',
+  'delete',
+  'publish',
+  'unpublish',
+  'discardDraft',
+]);
+
+/**
+ * `create` and `clone` mint a new documentId, so it only exists on the result.
+ * Every other action carries it on the params.
+ *
+ * @param {{ action: string, params?: any }} ctx
+ * @param {any} result
+ * @return {string|undefined}
+ */
+function resolveDocumentId(ctx, result) {
+  if (ctx.action === 'create' || ctx.action === 'clone') {
+    return result?.documentId;
+  }
+
+  return ctx.params?.documentId;
+}
+
+/**
+ * Invalidate the cache from the document service rather than from HTTP routes.
+ *
+ * Every write funnels through the document service - REST, GraphQL, the admin
+ * content-manager, the deprecated entity service, scheduled Content Releases,
+ * review workflows and any custom `strapi.documents()` call - so this catches
+ * writes that no route middleware can see, and cannot drift out of sync with
+ * Strapi's route list the way a hardcoded set of paths does.
+ *
+ * @see https://github.com/strapi-community/plugin-rest-cache/issues/129
+ *
+ * @param {Strapi} strapi
+ * @return {void}
+ */
+export const registerDocumentServiceMiddleware = function (strapi) {
+  debug('strapi:plugin-rest-cache')(
+    `[REGISTER] ${chalk.blueBright('document service')} invalidation middleware`
+  );
+
+  strapi.documents.use(async (ctx, next) => {
+    const result = await next();
+
+    if (!WRITE_ACTIONS.has(ctx.action)) {
+      return result;
+    }
+
+    const cacheConfig = strapi.plugin('rest-cache').service('cacheConfig');
+
+    if (!cacheConfig.isCached(ctx.uid)) {
+      return result;
+    }
+
+    const cacheStore = strapi.plugin('rest-cache').service('cacheStore');
+    const documentId = resolveDocumentId(ctx, result);
+
+    debug('strapi:plugin-rest-cache')(
+      `${chalk.redBright('[PURGE]')} ${ctx.action} ${chalk.cyan(ctx.uid)}${
+        documentId ? ` documentId=${documentId}` : ' (wildcard)'
+      }`
+    );
+
+    // Defer until the surrounding transaction commits. Several content-manager
+    // bulk operations wrap their loop in `strapi.db.transaction`, so purging
+    // inline risks either discarding a purge that gets rolled back, or
+    // repopulating the cache from pre-commit state. When there is no
+    // surrounding transaction this still runs, just immediately.
+    strapi.db.transaction(({ onCommit }) => {
+      onCommit(async () => {
+        try {
+          // Without a documentId we cannot scope the purge, so clear every
+          // entry for the content type.
+          await cacheStore.clearByUid(
+            ctx.uid,
+            documentId ? { id: documentId } : {},
+            !documentId
+          );
+        } catch (error) {
+          // A failed purge must never fail the write that triggered it.
+          strapi.log.error(
+            `REST Cache: failed to purge "${ctx.uid}" after "${ctx.action}"`
+          );
+          strapi.log.error(error);
+        }
+      });
+    });
+
+    return result;
+  });
+};

--- a/shared/config/cache-strategy.js
+++ b/shared/config/cache-strategy.js
@@ -19,6 +19,10 @@ module.exports = ({ env }) => ({
     ),
   contentTypes: [
     "api::article.article",
+    // A content type whose singular name ("editor") differs from its parent
+    // API ("writer"). See
+    // https://github.com/strapi-community/plugin-rest-cache/issues/125
+    "api::writer.editor",
     "api::global.global",
     "api::homepage.homepage",
     {

--- a/shared/src/api/writer/content-types/editor/schema.json
+++ b/shared/src/api/writer/content-types/editor/schema.json
@@ -1,0 +1,24 @@
+{
+  "kind": "collectionType",
+  "collectionName": "editors",
+  "info": {
+    "singularName": "editor",
+    "pluralName": "editors",
+    "displayName": "Editor",
+    "name": "editor",
+    "description": "A content type whose name differs from its parent API (api::writer.editor). Regression fixture for https://github.com/strapi-community/plugin-rest-cache/issues/125"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "email": {
+      "type": "string"
+    }
+  }
+}

--- a/shared/src/api/writer/controllers/editor.js
+++ b/shared/src/api/writer/controllers/editor.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/**
+ *  editor controller
+ */
+
+const { createCoreController } = require("@strapi/strapi").factories;
+
+module.exports = createCoreController("api::writer.editor");

--- a/shared/src/api/writer/routes/editor.js
+++ b/shared/src/api/writer/routes/editor.js
@@ -1,0 +1,13 @@
+"use strict";
+
+/**
+ * editor router.
+ *
+ * Deliberately lives under the `writer` API while describing the `editor`
+ * content type, so the plugin is exercised against a content type whose
+ * singular name does not match its parent API.
+ */
+
+const { createCoreRouter } = require("@strapi/strapi").factories;
+
+module.exports = createCoreRouter("api::writer.editor");

--- a/shared/src/api/writer/services/editor.js
+++ b/shared/src/api/writer/services/editor.js
@@ -1,0 +1,9 @@
+"use strict";
+
+/**
+ *  editor service
+ */
+
+const { createCoreService } = require("@strapi/strapi").factories;
+
+module.exports = createCoreService("api::writer.editor");

--- a/shared/src/bootstrap.js
+++ b/shared/src/bootstrap.js
@@ -42,10 +42,16 @@ async function setPublicPermissions(newPermissions) {
   const allPermissionsToCreate = [];
   Object.keys(newPermissions).map((controller) => {
     const actions = newPermissions[controller];
+    // A key may be a bare name ("article" -> api::article.article) or a full
+    // uid ("api::writer.editor") for content types whose name differs from
+    // their parent API.
+    const uid = controller.startsWith("api::")
+      ? controller
+      : `api::${controller}.${controller}`;
     const permissionsToCreate = actions.map((action) => {
       return strapi.query("plugin::users-permissions.permission").create({
         data: {
-          action: `api::${controller}.${controller}.${action}`,
+          action: `${uid}.${action}`,
           role: publicRole.id,
         },
       });
@@ -182,6 +188,7 @@ async function importSeedData() {
     article: ["find", "findOne"],
     category: ["find", "findBySlug", "findOne"],
     writer: ["find", "findOne"],
+    "api::writer.editor": ["find", "findOne"],
   });
 
   // Create all entries

--- a/shared/tests/cache-key-config.test.js
+++ b/shared/tests/cache-key-config.test.js
@@ -1,0 +1,190 @@
+"use strict";
+
+/**
+ * Coverage for the cache-key configuration surface.
+ *
+ * The shared strategy (shared/config/cache-strategy.js) configures a custom
+ * route, per-route maxAge and keys overrides, header-based keying and an
+ * explicit useQueryParams allow-list - none of which had any test coverage.
+ *
+ * `api::category.category` is the interesting one:
+ *
+ *   keys:    { useQueryParams: false, useHeaders: ["accept-encoding"] }
+ *   hitpass: false                       (overrides the global hitpass)
+ *   routes:  /api/categories/slug/:slug+ with
+ *            keys   { useQueryParams: ["populate", "locale"], useHeaders: [] }
+ *            maxAge 18000
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(60000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+describe("cache key configuration", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => strapi.plugin("rest-cache").service("cacheStore").reset());
+
+  describe("useQueryParams: false", () => {
+    it("ignores query params entirely when building the key", async () => {
+      const first = await agent().get("/api/categories");
+      const second = await agent().get("/api/categories?populate=*&sort=name");
+
+      expect(first.get("x-cache")).toBe("MISS");
+      // category is configured with useQueryParams: false, so a different
+      // query string must resolve to the same cache entry.
+      expect(second.get("x-cache")).toBe("HIT");
+    });
+  });
+
+  describe("useHeaders (vary)", () => {
+    it("stores separate entries per configured header value", async () => {
+      const first = await agent()
+        .get("/api/categories")
+        .set("Accept-Encoding", "gzip");
+      const second = await agent()
+        .get("/api/categories")
+        .set("Accept-Encoding", "br");
+
+      expect(first.get("x-cache")).toBe("MISS");
+      expect(second.get("x-cache")).toBe("MISS");
+    });
+
+    it("reuses the entry when the configured header matches", async () => {
+      const first = await agent()
+        .get("/api/categories")
+        .set("Accept-Encoding", "gzip");
+      const second = await agent()
+        .get("/api/categories")
+        .set("Accept-Encoding", "gzip");
+
+      expect(first.get("x-cache")).toBe("MISS");
+      expect(second.get("x-cache")).toBe("HIT");
+    });
+
+    it("ignores headers that are not configured", async () => {
+      const first = await agent()
+        .get("/api/categories")
+        .set("Accept-Encoding", "gzip")
+        .set("X-Custom", "one");
+      const second = await agent()
+        .get("/api/categories")
+        .set("Accept-Encoding", "gzip")
+        .set("X-Custom", "two");
+
+      expect(first.get("x-cache")).toBe("MISS");
+      expect(second.get("x-cache")).toBe("HIT");
+    });
+  });
+
+  describe("custom route with an explicit useQueryParams allow-list", () => {
+    it("caches a custom route", async () => {
+      const first = await agent().get("/api/categories/slug/news");
+      const second = await agent().get("/api/categories/slug/news");
+
+      expect(first.status).toBe(200);
+      expect(second.get("x-cache")).toBe("HIT");
+    });
+
+    it("keys separately on an allow-listed query param", async () => {
+      const first = await agent().get("/api/categories/slug/news");
+      const second = await agent().get(
+        "/api/categories/slug/news?populate=articles"
+      );
+
+      expect(first.get("x-cache")).toBe("MISS");
+      // `populate` is in the allow-list, so it must produce a distinct entry.
+      expect(second.get("x-cache")).toBe("MISS");
+    });
+
+    it("ignores query params outside the allow-list", async () => {
+      const first = await agent().get("/api/categories/slug/news");
+      const second = await agent().get("/api/categories/slug/news?sort=name");
+
+      expect(first.get("x-cache")).toBe("MISS");
+      // `sort` is not allow-listed, so it must not affect the key.
+      expect(second.get("x-cache")).toBe("HIT");
+    });
+
+    it("keys separately per route param", async () => {
+      const first = await agent().get("/api/categories/slug/news");
+      const second = await agent().get("/api/categories/slug/tech");
+
+      expect(first.get("x-cache")).toBe("MISS");
+      expect(second.get("x-cache")).toBe("MISS");
+    });
+
+    it("purges the custom route when the content type changes", async () => {
+      const warm = await agent().get("/api/categories/slug/news");
+      const hit = await agent().get("/api/categories/slug/news");
+      expect(warm.get("x-cache")).toBe("MISS");
+      expect(hit.get("x-cache")).toBe("HIT");
+
+      const [category] = await strapi
+        .documents("api::category.category")
+        .findMany({ filters: { slug: "news" }, limit: 1 });
+
+      await strapi.documents("api::category.category").update({
+        documentId: category.documentId,
+        data: { name: "news updated" },
+      });
+
+      const after = await agent().get("/api/categories/slug/news");
+      expect(after.get("x-cache")).toBe("MISS");
+    });
+  });
+
+  describe("per-contentType hitpass override", () => {
+    // The default hitpass triggers on an `authorization` OR a `cookie` header.
+    // We use `cookie` here deliberately: an invalid bearer token is rejected by
+    // Strapi's authenticate middleware, which runs BEFORE route middlewares, so
+    // the cache middleware would never execute and the assertion would be
+    // meaningless.
+    const SESSION = "session=abc123";
+
+    it("caches requests carrying a cookie when hitpass is disabled for the type", async () => {
+      // api::category.category sets hitpass: false, overriding the global
+      // hitpass, so it must still cache.
+      const first = await agent().get("/api/categories").set("Cookie", SESSION);
+      const second = await agent().get("/api/categories").set("Cookie", SESSION);
+
+      expect(first.get("x-cache")).toBe("MISS");
+      expect(second.get("x-cache")).toBe("HIT");
+    });
+
+    it("bypasses the cache for a content type using the default hitpass", async () => {
+      // api::article.article inherits the global hitpass.
+      const first = await agent().get("/api/articles").set("Cookie", SESSION);
+      const second = await agent().get("/api/articles").set("Cookie", SESSION);
+
+      expect(first.get("x-cache")).toBe("HITPASS");
+      expect(second.get("x-cache")).toBe("HITPASS");
+    });
+
+    it("does not let a hitpass request populate the cache for anonymous users", async () => {
+      await agent().get("/api/articles").set("Cookie", SESSION);
+
+      const anonymous = await agent().get("/api/articles");
+
+      expect(anonymous.get("x-cache")).toBe("MISS");
+    });
+
+    it("does not serve a cached entry to a hitpass request", async () => {
+      const warm = await agent().get("/api/articles");
+      const hit = await agent().get("/api/articles");
+      expect(warm.get("x-cache")).toBe("MISS");
+      expect(hit.get("x-cache")).toBe("HIT");
+
+      const authed = await agent().get("/api/articles").set("Cookie", SESSION);
+      expect(authed.get("x-cache")).toBe("HITPASS");
+    });
+  });
+});

--- a/shared/tests/content-type-api-name-mismatch.test.js
+++ b/shared/tests/content-type-api-name-mismatch.test.js
@@ -1,0 +1,93 @@
+"use strict";
+
+/**
+ * Coverage for content types whose name differs from their parent API.
+ *
+ * `api::writer.editor` lives under the `writer` API, so its routes are
+ * registered at `strapi.apis.writer.routes.editor` - there is no
+ * `strapi.apis.editor`. Resolving the API from the content type's singular
+ * name therefore crashed the whole application at register time with
+ * "Cannot read properties of undefined (reading 'routes')".
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/125
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(60000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const UID = "api::writer.editor";
+
+describe("content type whose name differs from its API", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => strapi.plugin("rest-cache").service("cacheStore").reset());
+
+  it("resolves default routes for the content type", () => {
+    const cacheConfig = strapi.plugin("rest-cache").service("cacheConfig");
+    const conf = cacheConfig.get(UID);
+
+    expect(conf).toBeDefined();
+
+    // Routes must come from the `writer` API but describe the `editor`
+    // content type, i.e. /api/editors rather than /api/writers.
+    const paths = conf.routes.map((route) => route.path);
+    expect(paths).toContain("/api/editors");
+    expect(paths).toContain("/api/editors/:id");
+    expect(paths).not.toContain("/api/writers");
+  });
+
+  it("caches the collection route", async () => {
+    const first = await agent().get("/api/editors");
+    const second = await agent().get("/api/editors");
+
+    expect(first.status).toBe(200);
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+  });
+
+  it("caches the single-entry route", async () => {
+    const editor = await strapi
+      .documents(UID)
+      .create({ data: { name: "Ada", email: "ada@example.com" } });
+
+    const first = await agent().get(`/api/editors/${editor.documentId}`);
+    const second = await agent().get(`/api/editors/${editor.documentId}`);
+
+    expect(first.status).toBe(200);
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+  });
+
+  it("purges when the content type changes", async () => {
+    const first = await agent().get("/api/editors");
+    const second = await agent().get("/api/editors");
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+
+    await strapi
+      .documents(UID)
+      .create({ data: { name: "Grace", email: "grace@example.com" } });
+
+    const third = await agent().get("/api/editors");
+    expect(third.get("x-cache")).toBe("MISS");
+  });
+
+  it("does not purge the sibling content type sharing the API", async () => {
+    // `writer` is not configured for caching, but the important part is that
+    // an `editor` write resolves to the editor routes only - the two content
+    // types share an API and must not be conflated.
+    const cacheConfig = strapi.plugin("rest-cache").service("cacheConfig");
+
+    expect(cacheConfig.isCached("api::writer.writer")).toBe(false);
+    expect(cacheConfig.isCached(UID)).toBe(true);
+  });
+});

--- a/shared/tests/document-service-purge.test.js
+++ b/shared/tests/document-service-purge.test.js
@@ -1,0 +1,167 @@
+"use strict";
+
+/**
+ * Coverage for cache invalidation on writes that never traverse an HTTP route.
+ *
+ * The plugin historically purged by injecting Koa middleware onto content-api
+ * and content-manager write routes. Anything writing through the document
+ * service directly - scheduled Content Releases, review-workflow transitions,
+ * GraphQL mutations, custom services, cron jobs, seed scripts - left the cache
+ * stale with no signal.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/129
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(60000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const UID = "api::article.article";
+
+async function warmArticleCache() {
+  const first = await agent().get("/api/articles");
+  const second = await agent().get("/api/articles");
+
+  expect(first.get("x-cache")).toBe("MISS");
+  expect(second.get("x-cache")).toBe("HIT");
+}
+
+describe("document service purge", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => strapi.plugin("rest-cache").service("cacheStore").reset());
+
+  it("purges when a document is updated outside of any HTTP request", async () => {
+    const [article] = await strapi
+      .documents(UID)
+      .findMany({ status: "published", limit: 1 });
+
+    await warmArticleCache();
+
+    await strapi.documents(UID).update({
+      documentId: article.documentId,
+      data: { title: "Updated by a background job" },
+    });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when a document is published outside of any HTTP request", async () => {
+    const [draft] = await strapi
+      .documents(UID)
+      .findMany({ status: "draft", limit: 1 });
+
+    await warmArticleCache();
+
+    await strapi.documents(UID).publish({ documentId: draft.documentId });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when a document is unpublished outside of any HTTP request", async () => {
+    const [article] = await strapi
+      .documents(UID)
+      .findMany({ status: "published", limit: 1 });
+
+    await warmArticleCache();
+
+    await strapi.documents(UID).unpublish({ documentId: article.documentId });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when a document is created outside of any HTTP request", async () => {
+    await warmArticleCache();
+
+    await strapi.documents(UID).create({
+      data: {
+        title: "Created by a background job",
+        description: "Created outside of any HTTP request",
+        content: "Body copy.",
+        slug: "created-by-a-job",
+      },
+      status: "published",
+    });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when a document is deleted outside of any HTTP request", async () => {
+    const [article] = await strapi
+      .documents(UID)
+      .findMany({ status: "published", limit: 1 });
+
+    await warmArticleCache();
+
+    await strapi.documents(UID).delete({ documentId: article.documentId });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("does not purge on reads", async () => {
+    await warmArticleCache();
+
+    // The document service middleware runs for reads too. If we purged on them,
+    // every cache hit would immediately invalidate itself.
+    await strapi.documents(UID).findMany({ status: "published" });
+    await strapi.documents(UID).findFirst({ status: "published" });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("HIT");
+  });
+
+  it("does not purge cached content types unrelated to the write", async () => {
+    // `homepage` has no relation to `article`, so writing to it must leave the
+    // article cache intact. Note the reverse is NOT true: `article` is related
+    // to every other cached type in this playground via the
+    // shared.seo -> sections.highlight -> article component chain, so writing
+    // an article legitimately purges everything (see the next test).
+    await warmArticleCache();
+
+    const [homepage] = await strapi
+      .documents("api::homepage.homepage")
+      .findMany({ limit: 1 });
+
+    await strapi.documents("api::homepage.homepage").update({
+      documentId: homepage.documentId,
+      data: { seo: { metaTitle: "Unrelated edit" } },
+    });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("HIT");
+  });
+
+  it("purges related content types when clearRelatedCache is enabled", async () => {
+    // `homepage` embeds article data through the sections.highlight component,
+    // so an article write has to invalidate the homepage too.
+    const first = await agent().get("/api/homepage");
+    const second = await agent().get("/api/homepage");
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+
+    const [article] = await strapi
+      .documents(UID)
+      .findMany({ status: "published", limit: 1 });
+
+    await strapi.documents(UID).update({
+      documentId: article.documentId,
+      data: { title: "Should invalidate the homepage too" },
+    });
+
+    const third = await agent().get("/api/homepage");
+    expect(third.get("x-cache")).toBe("MISS");
+  });
+});


### PR DESCRIPTION
Closes #129.

Replaces route-injected cache invalidation with `strapi.documents.use()`.

## Why

Invalidation was bolted onto HTTP routes: a purge middleware on content-api write routes, plus a **hardcoded list** of content-manager admin routes. Two structural problems:

1. **It could not cover writes that never traverse a route** — GraphQL mutations, scheduled Content Releases (which publish on a cron with no HTTP request at all), review-workflow transitions, custom `strapi.documents()` calls in services or cron jobs, seed scripts.
2. **The route list had to be manually re-verified against Strapi core on every release.** It had already drifted by 7 routes, which is what #127 fixed.

Every write funnels through the document service — REST core-api, GraphQL, admin content-manager, the deprecated entity service, content-releases — so invalidation can no longer be bypassed, and there is no list left to drift.

## Behaviour notes

- **Reads are filtered out.** The middleware runs for `findMany`/`findOne`/`count` too. Without the `WRITE_ACTIONS` filter every cache hit would immediately invalidate itself — there's a test pinning this.
- **`create` and `clone`** mint a new `documentId` that only exists on the *result*; every other action carries it on `ctx.params`.
- **Purges are deferred** with `strapi.db.transaction(({ onCommit }) => ...)`. Several content-manager bulk operations wrap their loop in a transaction, so purging inline risks either discarding a purge that gets rolled back, or repopulating the cache from pre-commit state. This is the pattern core uses in `document-service/events.ts`.
- **A failed purge is logged and swallowed** — it must never fail the write that triggered it.
- Without a resolvable `documentId`, the purge falls back to a wildcard clear for that content type.

## Migration

Gated behind `strategy.enableDocumentServiceMiddleware`, **default `true`**. When on, the route-injected `purge`/`purgeAdmin` middlewares are skipped — running both would purge twice for every routed write. Set it to `false` for the legacy behaviour, in which case `enableAdminCTBMiddleware` is honoured as before.

## Tests

`shared/tests/document-service-purge.test.js` covers create / update / delete / publish / unpublish with **no HTTP request at all**. All five failed before this change:

```
✕ purges when a document is updated outside of any HTTP request    Expected "MISS", Received "HIT"
✕ purges when a document is published outside of any HTTP request  Expected "MISS", Received "HIT"
✕ purges when a document is unpublished ...                        Expected "MISS", Received "HIT"
✕ purges when a document is created ...                            Expected "MISS", Received "HIT"
✕ purges when a document is deleted ...                            Expected "MISS", Received "HIT"
```

Two guard tests pin the opposite failure mode — over-purging:

- reads must not purge
- writing `homepage` must not purge `article`

That second one is deliberately in that direction. While writing it I verified at runtime that **`article` is related to every other cached content type in the playground**, through the `shared.seo → sections.highlight → article` component chain:

```
api::article.article  -> related+cached: [article, category, homepage, global]
api::homepage.homepage -> related+cached: [homepage]
```

So an article write legitimately purges everything, and my first attempt at this test asserted the wrong thing. A separate test now documents that related-purge behaviour explicitly. This is the `clearRelatedCache` amplification described in #131.

**The existing admin purge suite passes unchanged with route injection disabled**, which is the real confirmation that the document service hook covers everything the hardcoded list did — including the bulk publish/unpublish, clone and discard cases added in #136.

46/46 e2e.

## Follow-up this unlocks

`ctx.params.locale` is now available at purge time. `purgeAdmin` only ever saw `ctx.params`, so per-locale purging was impossible — a write to one locale had to clear every locale. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
