### PR TITLE
docs: sync README with the published 5.0.1 and backfill changelogs

### DIFF
--- a/packages/plugin-rest-cache/CHANGELOG.md
+++ b/packages/plugin-rest-cache/CHANGELOG.md
@@ -3,6 +3,73 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+
+* **ttl:** cache entries expired 1000x later than configured. `maxAge` is
+  milliseconds throughout the plugin, but both providers multiplied it by 1000
+  again before handing it to cache-manager, whose `set()` also takes
+  milliseconds - the default hour became 41.7 days, so entries effectively
+  never expired ([#126](https://github.com/strapi-community/plugin-rest-cache/issues/126))
+* **purge:** admin bulk publish, bulk unpublish, discard, clone and auto-clone
+  left the cache stale. Seven content-manager write routes were missing from
+  the hardcoded route list ([#127](https://github.com/strapi-community/plugin-rest-cache/issues/127))
+* **provider:** "Could not load REST Cache provider" and "Keyv is not a
+  constructor" on startup. `keyv` was undeclared and reached the providers only
+  via hoisting, and the ESM-only `quick-lru` was `require()`d from CommonJS,
+  which fails below Node 20.19. The underlying error is no longer replaced with
+  a misleading "you may need to install a provider" message
+  ([#128](https://github.com/strapi-community/plugin-rest-cache/issues/128), [#118](https://github.com/strapi-community/plugin-rest-cache/issues/118),
+  [#123](https://github.com/strapi-community/plugin-rest-cache/issues/123), [#116](https://github.com/strapi-community/plugin-rest-cache/issues/116))
+* **config:** a content type whose name differs from its parent API - such as
+  `api::writer.editor` - crashed the whole application at register time with
+  "Cannot read properties of undefined (reading 'routes')". The owning API is
+  now resolved from the uid ([#125](https://github.com/strapi-community/plugin-rest-cache/issues/125))
+* **routes:** custom routes ending in a repeatable param, such as
+  `/categories/slug/:slug+`, were silently never cached. The trailing `+` was
+  stripped from the configured path but not the registered one, so they could
+  never match
+* **purge:** the purge is awaited again, so a client that writes and
+  immediately reads sees fresh content. Deferring it to `onCommit` made it
+  fire-and-forget, because Strapi runs commit callbacks without awaiting them
+
+### Added
+
+* **invalidation:** cache invalidation now runs off the document service
+  (`strapi.documents.use()`) rather than injected route middleware. Writes that
+  never traverse an HTTP route - GraphQL mutations, scheduled Content Releases,
+  review-workflow transitions, custom `strapi.documents()` calls in services,
+  cron jobs or seed scripts - now invalidate correctly. Controlled by the new
+  `strategy.enableDocumentServiceMiddleware` option, default `true`; set it to
+  `false` for the previous route-based behaviour
+  ([#129](https://github.com/strapi-community/plugin-rest-cache/issues/129))
+* **packaging:** `engines.node` (`>=20.0.0`) is declared on the plugin and both
+  providers, so an unsupported Node fails at install rather than at boot
+
+### Changed
+
+* **BREAKING (behaviour):** because TTLs are now honoured, cached entries
+  expire when configured instead of lasting roughly 41 days. Expect a higher
+  miss rate and more origin traffic after upgrading. If `maxAge` or the
+  provider `ttl` was tuned around the previous behaviour, revisit it
+* when `enableDocumentServiceMiddleware` is enabled (the default), the route
+  `purge` and `purgeAdmin` middlewares are no longer injected, since the
+  document service already covers every write
+
+## 5.0.1
+
+### Changed
+
+* documentation only; no functional change. The published `dist/` output is
+  byte-for-byte identical to `5.0.0`
+
+## 5.0.0
+
+### Added
+
+* Strapi 5 support ([#112](https://github.com/strapi-community/plugin-rest-cache/pull/112))
+
 ## [4.2.4](https://github.com/strapi-community/strapi-plugin-rest-cache/compare/v4.2.3...v4.2.4) (2022-03-19)
 
 

--- a/packages/plugin-rest-cache/README.md
+++ b/packages/plugin-rest-cache/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 <h1>Strapi REST Cache Plugin</h1>
-	
+  
 <p style="margin-top: 0;">Speed-up HTTP requests with LRU cache.</p>
-	
+  
 <p>
   <a href="https://www.npmjs.org/package/@strapi-community/plugin-rest-cache">
     <img src="https://img.shields.io/npm/v/@strapi-community/plugin-rest-cache/latest.svg" alt="NPM Version" />
@@ -17,7 +17,6 @@
 
 - [🚦 Current Status](#-current-status)
 - [✨ Features](#-features)
-- [🤔 Motivation](#-motivation)
 - [🖐 Requirements](#-requirements)
 - [🚚 Getting Started](#-getting-started)
 - [Contributing](#contributing)
@@ -25,7 +24,7 @@
 
 ## 🚦 Current Status
 
-This package is currently under development and should be consider **ALPHA** in terms of state. I/We are currently accepting contributions and/or dedicated contributors to help develop and maintain this package.
+This package is currently under development and should be consider **BETA** in terms of state. I/We are currently accepting contributions and/or dedicated contributors to help develop and maintain this package.
 
 ## ✨ Features
 
@@ -38,10 +37,19 @@ You can set a **strategy** to tell what to cache and how much time responses sho
 
 Supported Strapi Versions:
 
-- Strapi v4.0.x (recently tested as of January 2022)
-- Strapi v4.x.x (Assumed, but possibly not tested)
+- Strapi v5.x.x (recently tested as of September 2025)
 
+**If you are looking for the Strapi v4.x support, please check the [legacy package](https://www.npmjs.com/package/strapi-plugin-rest-cache).**
 **If you are looking for a plugin for Strapi v3.x, please check the [strapi-middleware-cache](https://github.com/patrixr/strapi-middleware-cache/).**
+
+Node.js:
+
+- Node `>=20.0.0`
+
+Note that Strapi itself is the tighter constraint in practice: as of Strapi
+`5.52.0`, one of its transitive dependencies requires Node `>=22.13`, so a
+Strapi 5 application cannot be installed on Node 20 even though this plugin
+supports it.
 
 ## 🚚 Getting Started
 
@@ -51,7 +59,7 @@ Supported Strapi Versions:
 
 I/We are actively looking for contributors, maintainers, and others to help shape this package. As this plugins sole purpose within the Strapi community is to be used by other developers and plugin maintainers to get fast responses time.
 
-If interested please feel free to email the lead maintainer Sacha at: sacha@digisquad.io or ping `stf#3254` on Discord.
+If interested please feel free to open an issue or pull request.
 
 ## License
 

--- a/packages/provider-rest-cache-memory/CHANGELOG.md
+++ b/packages/provider-rest-cache-memory/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+
+* **ttl:** `maxAge` is milliseconds and was being multiplied by 1000 again
+  before being handed to cache-manager, whose `set()` also takes milliseconds.
+  The default hour became 41.7 days, so entries effectively never expired
+  ([#126](https://github.com/strapi-community/plugin-rest-cache/issues/126))
+* **deps:** `keyv` is now a declared dependency instead of arriving only via
+  hoisting, and is resolved tolerantly (`mod.default ?? mod`) so a keyv v4
+  hoisted by another package no longer causes "Keyv is not a constructor"
+  ([#128](https://github.com/strapi-community/plugin-rest-cache/issues/128))
+* **esm:** `quick-lru` v7 is ESM-only and was `require()`d from CommonJS, which
+  fails on any Node without `require(esm)` (added in 20.19) with
+  `ERR_REQUIRE_ESM`. It is now loaded with a dynamic `import()`, which works on
+  every supported Node version. Note downgrading to `quick-lru` v5 is not a
+  valid workaround: it lacks the iterator `keys()` depends on, which would
+  silently break all cache invalidation ([#128](https://github.com/strapi-community/plugin-rest-cache/issues/128))
+
+### Added
+
+* `engines.node` (`>=20.0.0`) is declared, so an unsupported Node fails at
+  install rather than mysteriously at boot
+
 ## [4.2.4](https://github.com/strapi-community/strapi-plugin-rest-cache/compare/v4.2.3...v4.2.4) (2022-03-19)
 
 **Note:** Version bump only for package strapi-provider-rest-cache-memory

--- a/packages/provider-rest-cache-redis/CHANGELOG.md
+++ b/packages/provider-rest-cache-redis/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Fixed
+
+* **ttl:** `maxAge` is milliseconds and was being multiplied by 1000 again
+  before being handed to cache-manager, whose `set()` also takes milliseconds.
+  The default hour became 41.7 days, so entries effectively never expired
+  ([#126](https://github.com/strapi-community/plugin-rest-cache/issues/126))
+* **deps:** `keyv` is now a declared dependency instead of arriving only via
+  hoisting, and is resolved tolerantly (`mod.default ?? mod`) so a keyv v4
+  hoisted by another package no longer causes "Keyv is not a constructor"
+  ([#128](https://github.com/strapi-community/plugin-rest-cache/issues/128))
+* **deps:** `@keyv/redis` is resolved tolerantly as well, since its CommonJS
+  build exposes only `.default` ([#128](https://github.com/strapi-community/plugin-rest-cache/issues/128))
+
+### Added
+
+* `engines.node` (`>=20.0.0`) is declared, so an unsupported Node fails at
+  install rather than mysteriously at boot
+
 ## [4.2.4](https://github.com/strapi-community/strapi-plugin-rest-cache/compare/v4.2.3...v4.2.4) (2022-03-19)
 
 **Note:** Version bump only for package strapi-provider-rest-cache-redis


### PR DESCRIPTION
Docs only. No version bump — 5.1.0 isn't being cut yet.

## The README had drifted out of git

The README shipped in npm `5.0.1` was edited at publish time and never committed. Git still says:

```
line 28: ...should be consider **ALPHA** in terms of state
line 41: - Strapi v4.0.x (recently tested as of January 2022)
```

while npm has told users **BETA** and *"Strapi v5.x.x (recently tested as of September 2025)"* since that release, plus a pointer to the legacy v4 package that git doesn't have.

**Publishing from `main` would have silently reverted the README on npm** — the kind of regression nobody catches, because nobody diffs a README on release.

## What 5.0.1 actually contained

I diffed the published tarballs rather than guessing:

```
5.0.0 dist files: 20   checksum 942c1eeb1d656da7d5868279f864122a
5.0.1 dist files: 20   checksum 942c1eeb1d656da7d5868279f864122a
```

**Byte-for-byte identical.** The only differences were the version field, an alphabetical re-sort of dependency keys, the README edit, and the addition of a (stale) CHANGELOG.

So there is **no untracked code in 5.0.1**. I'd previously flagged it as an unknown baseline for 5.1.0 — that concern was unfounded and I'm retracting it. The only thing that leaked out of git was documentation.

## Changes

**README** — brought in line with what was published, plus a Node requirement section. That ambiguity is exactly what produced #118 / #123 / #116, so it's worth stating. It also notes that Strapi is the tighter constraint in practice: as of 5.52.0 one of its transitive dependencies requires Node `>=22.13`, so a Strapi 5 app can't install on Node 20 even though this plugin supports it.

**Changelogs** — the plugin and both providers stopped at `4.2.4` and never documented the Strapi 5 migration at all. Adds an `Unreleased` section covering everything merged since `v5.0.0`, and records `5.0.1` as documentation-only.

The behaviour change is called out explicitly rather than buried in a bullet list:

> **BREAKING (behaviour):** because TTLs are now honoured, cached entries expire when configured instead of lasting roughly 41 days. Expect a higher miss rate and more origin traffic after upgrading.

Anyone who tuned `maxAge` or the provider `ttl` around the broken behaviour needs to revisit it, and that shouldn't be a surprise discovered in production.

## Worth deciding separately

The README drifted because it was edited during a manual publish, and the release workflow was removed in `6407e61` ("remove release workflow for now"). Restoring some form of release automation would prevent a recurrence — worth its own issue before 5.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
