### PR TITLE
fix: coalesce concurrent cache misses and stop racing the purge

### DIFF
--- a/packages/plugin-rest-cache/server/src/middlewares/recv.js
+++ b/packages/plugin-rest-cache/server/src/middlewares/recv.js
@@ -14,6 +14,21 @@ import { etagLookup } from '../utils/etags/etagLookup';
 import { etagMatch } from '../utils/etags/etagMatch';
 
 /**
+ * Requests currently fetching from the origin, keyed by cache key.
+ *
+ * Without this, N concurrent requests for the same uncached key each call the
+ * origin - the thundering herd a cache exists to prevent. It fires exactly when
+ * it hurts most: on a cold start, immediately after a purge, and at TTL expiry.
+ *
+ * Shared across every route's middleware instance, because the cache key is
+ * already unique per route and per configured key strategy.
+ *
+ * @see https://github.com/strapi-community/plugin-rest-cache/issues/130
+ * @type {Map<string, Promise<{ body: any, status: number }>>}
+ */
+const inFlight = new Map();
+
+/**
  * @param {{ cacheRouteConfig: CacheRouteConfig }} options
  * @param {{ strapi: import('@strapi/strapi').Strapi }} context
  */
@@ -77,10 +92,59 @@ export default function createRecv(options, { strapi }) {
         ctx.body = cacheEntry;
         return;
       }
+
+      // Cache miss. If an identical request is already fetching, wait for its
+      // result instead of making our own trip to the origin.
+      const pending = inFlight.get(cacheKey);
+
+      if (pending) {
+        try {
+          const shared = await pending;
+
+          debug('strapi:plugin-rest-cache')(
+            `[RECV] GET ${cacheKey} ${colors.yellow('MISS')} ${colors.grey('(coalesced)')}`
+          );
+
+          if (enableXCacheHeaders) {
+            ctx.set('X-Cache', 'MISS');
+          }
+
+          ctx.status = shared.status;
+          ctx.body = shared.body;
+          return;
+        } catch {
+          // The request we were waiting on failed. Fall through and fetch
+          // independently rather than inheriting an unrelated failure.
+        }
+      }
     }
 
-    // fetch backend
-    await next();
+    // Only the request that reaches the origin publishes its result; waiters
+    // never register themselves, so a failure cannot cascade.
+    let publish;
+    let abandon;
+
+    if (lookup) {
+      const shared = new Promise((resolve, reject) => {
+        publish = resolve;
+        abandon = reject;
+      });
+      // Nothing may be waiting yet, and an unobserved rejection would warn.
+      shared.catch(() => {});
+      inFlight.set(cacheKey, shared);
+    }
+
+    try {
+      // fetch backend
+      await next();
+    } catch (error) {
+      abandon?.(error);
+      throw error;
+    } finally {
+      if (lookup) {
+        inFlight.delete(cacheKey);
+      }
+    }
 
     // fetch done
     if (!lookup) {
@@ -101,28 +165,48 @@ export default function createRecv(options, { strapi }) {
       ctx.set('X-Cache', 'MISS');
     }
 
+    // Hand the response to anything waiting on us before writing to the cache,
+    // so waiters are not blocked on the store.
+    publish?.({ body: ctx.body, status: ctx.status });
+
     if (ctx.body && ctx.status >= 200 && ctx.status <= 300) {
       // @TODO check Cache-Control response header
+
+      const writes = [];
 
       if (enableEtag) {
         const etag = etagGenerate(ctx, cacheKey);
 
         ctx.set('ETag', `"${etag}"`);
 
-        // persist etag asynchronously
-        store.set(`${cacheKey}_etag`, etag, maxAge).catch(() => {
-          debug('strapi:plugin-rest-cache')(
-            `[RECV] GET ${cacheKey} ${colors.yellow('Unable to store ETag in cache')}`
-          );
-        });
+        writes.push(
+          store.set(`${cacheKey}_etag`, etag, maxAge).catch(() => {
+            debug('strapi:plugin-rest-cache')(
+              `[RECV] GET ${cacheKey} ${colors.yellow('Unable to store ETag in cache')}`
+            );
+          })
+        );
       }
 
-      // persist cache asynchronously
-      store.set(cacheKey, ctx.body, maxAge).catch(() => {
-        debug('strapi:plugin-rest-cache')(
-          `[RECV] GET ${cacheKey} ${colors.yellow('Unable to store Content in cache')}`
-        );
-      });
+      writes.push(
+        store.set(cacheKey, ctx.body, maxAge).catch(() => {
+          debug('strapi:plugin-rest-cache')(
+            `[RECV] GET ${cacheKey} ${colors.yellow('Unable to store Content in cache')}`
+          );
+        })
+      );
+
+      // Await the writes rather than firing and forgetting them.
+      //
+      // An unawaited write outlives the request, so a purge triggered by a
+      // concurrent write can complete first and then be undone by this write
+      // landing afterwards - repopulating the cache with data read before the
+      // change, which then survives until maxAge. The body and its ETag were
+      // also written independently, so a stale ETag could outlive its body and
+      // drive 304s against content that no longer existed.
+      //
+      // See https://github.com/strapi-community/plugin-rest-cache/issues/132
+      await Promise.all(writes);
     }
   };
 }

--- a/shared/tests/request-coalescing.test.js
+++ b/shared/tests/request-coalescing.test.js
@@ -1,0 +1,141 @@
+"use strict";
+
+/**
+ * Coverage for concurrent cache misses.
+ *
+ * On a miss the plugin used to call the origin directly, with no in-flight
+ * deduplication, so N concurrent requests for the same uncached key produced N
+ * origin queries. That is the thundering herd a cache exists to prevent, and it
+ * fires exactly when it hurts most: on a cold start, after a purge, and at TTL
+ * expiry.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/130
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(90000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const UID = "api::article.article";
+const CONCURRENCY = 10;
+
+let baseUrl;
+
+/**
+ * Fire N genuinely concurrent requests.
+ *
+ * supertest is not usable here: a fresh agent per request opens N connections
+ * and the server resets them, and a shared agent is not designed for parallel
+ * use. Either way the test fails for reasons unrelated to caching. Listening on
+ * a real port and using fetch gives honest concurrency.
+ */
+async function burst(path, n = CONCURRENCY, headers = {}) {
+  const responses = await Promise.all(
+    Array.from({ length: n }, () => fetch(`${baseUrl}${path}`, { headers }))
+  );
+
+  return Promise.all(
+    responses.map(async (res) => ({
+      status: res.status,
+      body: await res.json(),
+      get: (h) => res.headers.get(h),
+    }))
+  );
+}
+
+/** Counts origin reads, incremented by a document service middleware. */
+let originReads = 0;
+
+/**
+ * Artificial origin latency.
+ *
+ * Without it this test passes even with no coalescing at all: an in-memory
+ * response is fast enough that the first request populates the cache before
+ * the others reach the handler, so they never actually overlap and the test is
+ * green for the wrong reason. A slow origin guarantees the requests are in
+ * flight simultaneously, which is the condition being tested.
+ */
+const ORIGIN_LATENCY_MS = 250;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("request coalescing", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+
+    await new Promise((resolve) => strapi.server.httpServer.listen(0, resolve));
+    baseUrl = `http://127.0.0.1:${strapi.server.httpServer.address().port}`;
+
+    // Every REST read for this content type goes through the document service,
+    // so this counts actual trips to the origin rather than inferring from
+    // response headers.
+    strapi.documents.use(async (ctx, next) => {
+      if (ctx.uid === UID && (ctx.action === "findMany" || ctx.action === "findOne")) {
+        originReads += 1;
+        await sleep(ORIGIN_LATENCY_MS);
+      }
+      return next();
+    });
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(async () => {
+    await strapi.plugin("rest-cache").service("cacheStore").reset();
+    originReads = 0;
+  });
+
+  it("hits the origin once for concurrent misses on the same key", async () => {
+    const responses = await burst("/api/articles");
+
+    for (const res of responses) {
+      expect(res.status).toBe(200);
+    }
+
+    expect(originReads).toBe(1);
+  });
+
+  it("serves every coalesced request the same body", async () => {
+    const responses = await burst("/api/articles");
+
+    const bodies = new Set(responses.map((res) => JSON.stringify(res.body)));
+    expect(bodies.size).toBe(1);
+    expect(responses[0].body.data.length).toBeGreaterThan(0);
+  });
+
+  it("does not coalesce across different cache keys", async () => {
+    const [articles, homepage] = await Promise.all([
+      fetch(`${baseUrl}/api/articles`),
+      fetch(`${baseUrl}/api/articles?populate=*`),
+    ]);
+
+    expect(articles.status).toBe(200);
+    expect(homepage.status).toBe(200);
+    // Different query strings are different cache keys, so both must reach the
+    // origin rather than one waiting on the other's result.
+    expect(originReads).toBe(2);
+  });
+
+  it("populates the cache once so later requests hit", async () => {
+    await burst("/api/articles");
+
+    const after = await fetch(`${baseUrl}/api/articles`);
+    expect(after.headers.get("x-cache")).toBe("HIT");
+    expect(originReads).toBe(1);
+  });
+
+  it("still reaches the origin for every request that bypasses the cache", async () => {
+    // hitpass requests are deliberately not cached, so they must not be
+    // coalesced either - each caller needs its own uncached response.
+    const responses = await burst("/api/articles", 5, { Cookie: "session=abc" });
+
+    for (const res of responses) {
+      expect(res.get("x-cache")).toBe("HITPASS");
+    }
+    expect(originReads).toBe(5);
+  });
+});


### PR DESCRIPTION
Closes #130. Closes #132.

## Request coalescing (#130)

On a miss the plugin called the origin directly with no in-flight deduplication, so N concurrent requests for the same uncached key produced N origin queries — the thundering herd a cache exists to prevent. It fires exactly when it hurts most: cold start, immediately after a purge, and at TTL expiry. And the default `hitpass` means the cache serves anonymous traffic, the highest-fanout tier.

The first request to miss now publishes its result to any identical request arriving while it's still fetching. **Waiters never register themselves**, so a failure can't cascade — if the request being waited on throws, the waiter falls through and fetches independently rather than inheriting an unrelated error. Requests that bypass the cache are never coalesced, since each caller needs its own uncached response.

## Awaited cache writes (#132)

The body and its ETag were written fire-and-forget. An unawaited write outlives the request, so a purge triggered by a concurrent write could complete *first* and then be undone by this write landing afterwards — repopulating the cache with data read before the change, which then survived until `maxAge`.

The two writes were also independent, so a stale ETag could outlive its body and drive 304s against content that no longer existed.

Both are now awaited together, after the response is handed to waiters so they aren't blocked on the store.

## The test needed two fixes to be honest

**supertest can't express this.** A fresh agent per request opens N connections and the server resets them (`ECONNRESET`); a shared agent isn't built for parallel use. Both fail for reasons unrelated to caching. The test listens on a real port and uses `fetch`.

**More importantly, the first version passed with no implementation at all.** An in-memory response is fast enough that the first request populates the cache before the others reach the handler — they never actually overlapped, so it was green for the wrong reason. A test that passes before the fix proves nothing.

The counting middleware now adds 250 ms of artificial origin latency to guarantee genuine concurrency. With that, the pre-fix run reported:

```
✕ hits the origin once for concurrent misses on the same key
    Expected: 1
    Received: 10
```

Origin reads are counted through a document service middleware rather than inferred from response headers.

Guards in the other direction: different cache keys must **not** coalesce, and hitpass requests must each reach the origin.

## Verification

70/70 e2e on both memory and redis (up from 65), lint clean.

## Not included

#131 (purge enumerating the whole keyspace) is the remaining item in this batch and needs a provider-interface change — `delMany`, a native `clear()`, and a capability flag. That's a breaking change for third-party providers, so it belongs with #100 and #114 in one deliberate major rather than bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)