### PR TITLE
perf: batch cache purges instead of one round trip per key

### DIFF
--- a/packages/plugin-rest-cache/server/src/services/cacheStore.js
+++ b/packages/plugin-rest-cache/server/src/services/cacheStore.js
@@ -114,6 +114,37 @@ export default function createCacheStoreService({ strapi }) {
       }
     },
 
+    /**
+     * @param {string[]} keys
+     */
+    async delMany(keys) {
+      if (!initialized) {
+        strapi.log.error('REST Cache provider not initialized');
+        return null;
+      }
+
+      if (!this.ready) {
+        strapi.log.error('REST Cache provider not ready');
+        return null;
+      }
+
+      if (!keys.length) {
+        return null;
+      }
+
+      debug('strapi:plugin-rest-cache')(
+        `${colors.redBright('[PURGING]')}: ${keys.length} key(s)`
+      );
+
+      try {
+        return await provider.delMany(keys.map((key) => `${keysPrefix}${key}`));
+      } catch (error) {
+        strapi.log.error(`REST Cache provider errored:`);
+        strapi.log.error(error);
+        return null;
+      }
+    },
+
     async keys() {
       if (!initialized) {
         strapi.log.error('REST Cache provider not initialized');
@@ -154,7 +185,14 @@ export default function createCacheStoreService({ strapi }) {
       }
 
       try {
-        return this.keys().then((keys) => Promise.all(keys.map((key) => this.del(key))));
+        // A prefixed store shares its keyspace with other consumers, so only
+        // the keys belonging to this cache may be removed. Without a prefix the
+        // provider can flush everything it holds in one operation.
+        if (keysPrefix) {
+          return await this.delMany((await this.keys()) || []);
+        }
+
+        return await provider.clear();
       } catch (error) {
         strapi.log.error(`REST Cache provider errored:`);
         strapi.log.error(error);
@@ -182,12 +220,10 @@ export default function createCacheStoreService({ strapi }) {
        */
       const shouldDel = (key) => regExps.find((r) => r.test(key.replace(keysPrefix, '')));
 
-      /**
-       * @param {string} key
-       */
-      const del = (key) => this.del(key);
-
-      await Promise.all(keys.filter(shouldDel).map(del));
+      // One batched delete rather than an unbounded Promise.all of individual
+      // deletes, which on redis was a round trip per key and opened as many
+      // simultaneous operations as there were matches.
+      await this.delMany(keys.filter(shouldDel));
     },
 
     /**

--- a/packages/plugin-rest-cache/server/src/types/CacheProvider.js
+++ b/packages/plugin-rest-cache/server/src/types/CacheProvider.js
@@ -38,8 +38,38 @@ export class CacheProvider {
     throw new Error("Method 'del()' must be implemented.");
   }
 
+  /**
+   * Delete many keys at once.
+   *
+   * Optional. This default is intentionally conservative so existing providers
+   * keep working unchanged - it just deletes one at a time, with bounded
+   * concurrency so a large purge cannot open thousands of simultaneous
+   * connections. Providers backed by a store with a batch delete should
+   * override it; a purge is otherwise one round trip per key.
+   *
+   * @see https://github.com/strapi-community/plugin-rest-cache/issues/131
+   * @param {string[]} keys
+   */
+  async delMany(keys) {
+    const CONCURRENCY = 16;
+
+    for (let i = 0; i < keys.length; i += CONCURRENCY) {
+      await Promise.all(keys.slice(i, i + CONCURRENCY).map((key) => this.del(key)));
+    }
+  }
+
   async keys() {
     throw new Error("Method 'keys()' must be implemented.");
+  }
+
+  /**
+   * Remove every entry this provider holds.
+   *
+   * Optional. Defaults to enumerating and deleting, which is what the store did
+   * before this existed. Providers with a native flush should override it.
+   */
+  async clear() {
+    await this.delMany(await this.keys());
   }
 
   get ready() {

--- a/packages/provider-rest-cache-memory/lib/MemoryCacheProvider.js
+++ b/packages/provider-rest-cache-memory/lib/MemoryCacheProvider.js
@@ -85,12 +85,25 @@ class MemoryCacheProvider extends CacheProvider {
     return this.cache.del(key);
   }
 
+  /**
+   * @param {string[]} keys
+   */
+  async delMany(keys) {
+    if (!keys.length) return;
+
+    await this.cache.mdel(keys);
+  }
+
   async keys() {
     const keys = [];
     for await (const [key] of this.cache.stores[0].iterator({})) {
       keys.push(key);
     }
     return keys;
+  }
+
+  async clear() {
+    await this.cache.clear();
   }
 
   get ready() {

--- a/packages/provider-rest-cache-redis/lib/RedisCacheProvider.js
+++ b/packages/provider-rest-cache-redis/lib/RedisCacheProvider.js
@@ -56,12 +56,76 @@ class RedisCacheProvider extends CacheProvider {
     return this.cache.del(key);
   }
 
+  /**
+   * @param {string[]} keys
+   */
+  async delMany(keys) {
+    if (!keys.length) return;
+
+    const store = this.cache.stores[0].opts.store;
+    const namespace = store._getNamespace?.();
+
+    // @keyv/redis's own deleteMany maps over delete(), issuing a MULTI of
+    // UNLINK + SREM per key, all in flight at once. Sending one MULTI for the
+    // whole batch turns a round trip per key into a round trip per chunk.
+    if (store.redis && namespace && store.namespace && store.opts?.useRedisSets !== false) {
+      // Chunked so a large purge does not build a single enormous command.
+      const CHUNK = 1000;
+      const qualified = keys.map((key) => `${store.namespace}:${key}`);
+
+      for (let i = 0; i < qualified.length; i += CHUNK) {
+        const batch = qualified.slice(i, i + CHUNK);
+        const trx = store.redis.multi();
+        trx.unlink(...batch);
+        trx.srem(namespace, ...batch);
+        await trx.exec();
+      }
+
+      return;
+    }
+
+    await this.cache.mdel(keys);
+  }
+
   async keys() {
+    // @keyv/redis maintains a set of every key it has written (it SADDs on
+    // write and SREMs on delete), so the key names can be read directly.
+    //
+    // The obvious alternative - iterating the keyv store - is what this used to
+    // do, and it is enormously more expensive: it SCANs the whole Redis
+    // keyspace at ioredis' default COUNT of 10, and MGETs a batch of *values*
+    // for every page, purely to enumerate names. Measured over 100k entries
+    // that was roughly 20,000 round trips and 55MB transferred, against 1 round
+    // trip here.
+    //
+    // See https://github.com/strapi-community/plugin-rest-cache/issues/131
+    const store = this.cache.stores[0].opts.store;
+    const namespace = store._getNamespace?.();
+
+    if (typeof store.redis?.smembers === 'function' && namespace && store.namespace) {
+      const members = await store.redis.smembers(namespace);
+
+      // The tracking set holds fully qualified redis keys ("keyv:/api/foo"),
+      // whereas the iterator - and therefore every caller of this method -
+      // yields them unqualified ("/api/foo"). Returning the qualified form
+      // silently breaks purging: the regexes never match and the deletes
+      // address keys that do not exist.
+      const prefix = `${store.namespace}:`;
+      return members.map((key) => (key.startsWith(prefix) ? key.slice(prefix.length) : key));
+    }
+
+    // Fall back to enumeration if the adapter does not expose its key set,
+    // which is the case for a redis cluster client.
     const keys = [];
     for await (const [key] of this.cache.stores[0].iterator({})) {
       keys.push(key);
     }
     return keys;
+  }
+
+  async clear() {
+    // Removes every key and the tracking set in one operation.
+    await this.cache.clear();
   }
 
   get ready() {

--- a/shared/tests/purge-scalability.test.js
+++ b/shared/tests/purge-scalability.test.js
@@ -1,0 +1,106 @@
+"use strict";
+
+/**
+ * Coverage for how a purge removes entries, not just that it does.
+ *
+ * clearByRegexp used to enumerate the whole keyspace and then issue one delete
+ * per matching key through an unbounded Promise.all. On redis that is a round
+ * trip per key, and enumeration itself SCANned the entire keyspace and MGETted
+ * every value purely to read key names.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/131
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(90000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const store = () => strapi.plugin("rest-cache").service("cacheStore");
+
+describe("purge scalability", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => store().reset());
+
+  it("exposes a batched delete", () => {
+    expect(typeof store().delMany).toBe("function");
+  });
+
+  it("deletes many keys in a single provider call", async () => {
+    const target = store();
+
+    // Wrap the store's own delMany so we can count how the purge path uses it,
+    // without needing access to the private provider instance.
+    const calls = [];
+    const original = target.delMany.bind(target);
+    target.delMany = async (keys) => {
+      calls.push(keys.length);
+      return original(keys);
+    };
+
+    try {
+      for (let i = 0; i < 25; i += 1) {
+        await target.set(`/api/articles?page=${i}&`, { page: i }, 60000);
+      }
+      expect((await target.keys()).length).toBeGreaterThanOrEqual(25);
+
+      await target.clearByRegexp([/^\/api\/articles/]);
+
+      // One batched call, not one per key.
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toBeGreaterThanOrEqual(25);
+    } finally {
+      target.delMany = original;
+    }
+  });
+
+  it("removes exactly the matching keys", async () => {
+    const target = store();
+
+    await target.set("/api/articles?&", { a: 1 }, 60000);
+    await target.set("/api/articles/1?&", { a: 2 }, 60000);
+    await target.set("/api/homepage?&", { h: 1 }, 60000);
+
+    await target.clearByRegexp([/^\/api\/articles/]);
+
+    const remaining = await target.keys();
+    expect(remaining).toContain("/api/homepage?&");
+    expect(remaining.filter((k) => k.startsWith("/api/articles"))).toHaveLength(0);
+  });
+
+  it("reset removes every entry", async () => {
+    const target = store();
+
+    await target.set("/api/articles?&", { a: 1 }, 60000);
+    await target.set("/api/homepage?&", { h: 1 }, 60000);
+    expect((await target.keys()).length).toBeGreaterThan(0);
+
+    await target.reset();
+
+    expect(await target.keys()).toHaveLength(0);
+  });
+
+  it("purging a content type still invalidates its cached responses", async () => {
+    const first = await agent().get("/api/articles");
+    const second = await agent().get("/api/articles");
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+
+    await store().clearByUid("api::article.article", {}, true);
+
+    const third = await agent().get("/api/articles");
+    expect(third.get("x-cache")).toBe("MISS");
+  });
+
+  it("tolerates a purge that matches nothing", async () => {
+    await expect(store().clearByRegexp([/^\/api\/nothing-here/])).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #131.

## No breaking change — I was wrong about that

`delMany()` and `clear()` are added to `CacheProvider` **with working defaults**, so providers that don't implement them behave exactly as before. The defaults *are* the old code paths, just with bounded concurrency instead of an unbounded `Promise.all`.

Provider validation is a constructor-name walk (`looksLikeInstanceof`), so extending the base class cannot invalidate an existing subclass. The same approach works for #100 and #114 — I'd conflated "the interface should eventually be redesigned" (true, and #140's job) with "it can't be improved now" (false).

## Enumeration: ~400 commands and the whole cache transferred → 1

`clearByRegexp` starts by listing every key. On redis that meant iterating the keyv store, which SCANs the entire keyspace at ioredis' default `COUNT` of 10 and MGETs a page of **values** for each batch — fetching every cached response body purely to read key *names*.

`@keyv/redis` already maintains a set of every key it writes (SADD on write, SREM on delete), so the names can be read directly.

```
keys() over 2000 entries -> {"smembers": 1}
```

### A trap worth recording

The tracking set holds **fully qualified** keys (`keyv:/api/foo`) while the iterator — and therefore every caller — yields them **unqualified** (`/api/foo`).

Returning the qualified form silently breaks purging: the regexes match nothing and the deletes address keys that don't exist. It surfaced as **44 failures across the redis suite**, every one of them "expected MISS, received HIT". Nothing about the symptom points at key prefixing.

## Deletion: 1500 commands → 2

Matching keys were deleted individually through an unbounded `Promise.all`, one round trip each. `@keyv/redis`'s own `deleteMany` doesn't help — it maps over `delete()`, issuing a MULTI of UNLINK + SREM **per key**.

The redis provider now sends one MULTI per 1000 keys:

```
delMany(1500) -> {"multi": 2}
remaining              : 500
deleted key gone       : true
survivor intact        : {"i":1993}
```

Chunked so a large purge can't build one enormous command.

`reset()` uses the provider's native `clear()` when no `keysPrefix` is configured. With a prefix the store shares its keyspace with other consumers, so it still enumerates and deletes only what belongs to it.

## Tests

`shared/tests/purge-scalability.test.js` asserts the purge path issues **one batched call rather than one per key** — by wrapping the store's `delMany` and counting — and that a purge removes exactly the matching keys and leaves the rest.

76/76 e2e on both providers, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)