### PR TITLE
fix: refuse to cache responses that cannot be safely replayed

### DIFF
--- a/packages/plugin-rest-cache/server/src/middlewares/recv.js
+++ b/packages/plugin-rest-cache/server/src/middlewares/recv.js
@@ -12,6 +12,7 @@ import { shouldLookup } from '../utils/middlewares/shouldLookup';
 import { etagGenerate } from '../utils/etags/etagGenerate';
 import { etagLookup } from '../utils/etags/etagLookup';
 import { etagMatch } from '../utils/etags/etagMatch';
+import { isCacheable } from '../utils/middlewares/isCacheable';
 
 /**
  * Requests currently fetching from the origin, keyed by cache key.
@@ -169,9 +170,16 @@ export default function createRecv(options, { strapi }) {
     // so waiters are not blocked on the store.
     publish?.({ body: ctx.body, status: ctx.status });
 
-    if (ctx.body && ctx.status >= 200 && ctx.status <= 300) {
-      // @TODO check Cache-Control response header
+    const { cacheable, reason } = isCacheable(ctx);
 
+    if (!cacheable) {
+      debug('strapi:plugin-rest-cache')(
+        `[RECV] GET ${cacheKey} ${colors.grey(`not cached: ${reason}`)}`
+      );
+      return;
+    }
+
+    {
       const writes = [];
 
       if (enableEtag) {

--- a/packages/plugin-rest-cache/server/src/utils/middlewares/isCacheable.js
+++ b/packages/plugin-rest-cache/server/src/utils/middlewares/isCacheable.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Whether a response can be stored and replayed to a different caller.
+ *
+ * The cache captures ctx.body and serves it again later, which quietly assumes
+ * the body is a plain serialisable value and that the response is not specific
+ * to the caller who triggered it. Neither holds for every response.
+ *
+ * @see https://github.com/strapi-community/plugin-rest-cache/issues/133
+ *
+ * @param {import('koa').Context} ctx
+ * @return {{ cacheable: boolean, reason?: string }}
+ */
+export const isCacheable = function (ctx) {
+  // The handler took over the socket and wrote the response itself, so ctx.body
+  // is not the response at all. Strapi's own /mcp route does this.
+  if (ctx.respond === false) {
+    return { cacheable: false, reason: 'handler set ctx.respond = false' };
+  }
+
+  if (!ctx.body) {
+    return { cacheable: false, reason: 'empty body' };
+  }
+
+  if (!(ctx.status >= 200 && ctx.status <= 300)) {
+    return { cacheable: false, reason: `status ${ctx.status}` };
+  }
+
+  // A stream can only be consumed once. Storing it caches an object that
+  // cannot be replayed, and the entry poisons every later request for the key.
+  if (typeof ctx.body.pipe === 'function') {
+    return { cacheable: false, reason: 'streamed body' };
+  }
+
+  // Set-Cookie is issued to one caller. Replaying it hands that caller's
+  // session, CSRF token or consent state to everybody else who shares the key.
+  const setCookie = ctx.response.get('Set-Cookie');
+  if (setCookie && setCookie.length) {
+    return { cacheable: false, reason: 'response sets a cookie' };
+  }
+
+  // Respect an explicit instruction from the handler not to store the response.
+  const cacheControl = String(ctx.response.get('Cache-Control') || '');
+  if (/(^|,)\s*(no-store|private)\s*(,|$)/i.test(cacheControl)) {
+    return { cacheable: false, reason: `Cache-Control: ${cacheControl}` };
+  }
+
+  return { cacheable: true };
+};

--- a/shared/config/cache-strategy.js
+++ b/shared/config/cache-strategy.js
@@ -42,6 +42,11 @@ module.exports = ({ env }) => ({
         useHeaders: ["accept-encoding"],
       },
       routes: [
+        // Deliberately configured for caching so the plugin's refusal to cache
+        // them is exercised, rather than assumed.
+        { path: "/api/categories/probe/raw", method: "GET" },
+        { path: "/api/categories/probe/stream", method: "GET" },
+        { path: "/api/categories/probe/with-cookie", method: "GET" },
         {
           path: "/api/categories/slug/:slug+",
           keys: {

--- a/shared/config/server.js
+++ b/shared/config/server.js
@@ -6,4 +6,22 @@ module.exports = ({ env }) => ({
   app: {
     keys: env.array("APP_KEYS", ["testKey1", "testKey2"]),
   },
+  // Strapi's MCP endpoint is opt-in, and must stay off here.
+  //
+  // The content-manager derives MCP tool names with slugifyUidForMcpToolName,
+  // which for "api::x.y" returns only the API segment and discards the content
+  // type. This playground has api::writer.writer and api::writer.editor, so
+  // both derive the name "writer" and registration throws:
+  //
+  //   [MCP] tool with name "list_writer" is already registered.
+  //
+  // That takes the whole application down at bootstrap. It affects any Strapi
+  // 5.52 app with two content types in one API - the same class of bug as
+  // plugin-rest-cache#125, identity derived from the API name rather than the
+  // content type.
+  //
+  // Set ENABLE_MCP=true to reproduce it.
+  mcp: {
+    enabled: env.bool("ENABLE_MCP", false),
+  },
 });

--- a/shared/src/api/category/controllers/category.js
+++ b/shared/src/api/category/controllers/category.js
@@ -9,6 +9,30 @@ const { createCoreController } = require("@strapi/strapi").factories;
 module.exports = createCoreController(
   "api::category.category",
   ({ strapi }) => ({
+    /**
+     * Writes straight to the raw socket, the way Strapi's own /mcp route does.
+     * Koa is told not to handle the response at all.
+     */
+    async raw(ctx) {
+      ctx.respond = false;
+      ctx.res.statusCode = 200;
+      ctx.res.setHeader("Content-Type", "application/json");
+      ctx.res.end(JSON.stringify({ raw: true }));
+    },
+
+    /** A streamed body, which cannot be serialised into a cache entry. */
+    async stream(ctx) {
+      const { Readable } = require("stream");
+      ctx.type = "application/json";
+      ctx.body = Readable.from([JSON.stringify({ streamed: true })]);
+    },
+
+    /** A response carrying a Set-Cookie, which must never be shared. */
+    async withCookie(ctx) {
+      ctx.cookies.set("session", `s-${Date.now()}`, { httpOnly: true });
+      ctx.body = { cookie: true };
+    },
+
     async findBySlug(ctx) {
       const { slug } = ctx.params;
       const { query } = ctx;

--- a/shared/src/api/category/routes/custom-category.js
+++ b/shared/src/api/category/routes/custom-category.js
@@ -7,5 +7,22 @@ module.exports = {
       path: "/categories/slug/:slug+",
       handler: "category.findBySlug",
     },
+    // Fixtures for responses the cache must refuse to buffer. See
+    // https://github.com/strapi-community/plugin-rest-cache/issues/133
+    {
+      method: "GET",
+      path: "/categories/probe/raw",
+      handler: "category.raw",
+    },
+    {
+      method: "GET",
+      path: "/categories/probe/stream",
+      handler: "category.stream",
+    },
+    {
+      method: "GET",
+      path: "/categories/probe/with-cookie",
+      handler: "category.withCookie",
+    },
   ],
 };

--- a/shared/src/bootstrap.js
+++ b/shared/src/bootstrap.js
@@ -186,7 +186,7 @@ async function importSeedData() {
     global: ["find"],
     homepage: ["find"],
     article: ["find", "findOne"],
-    category: ["find", "findBySlug", "findOne"],
+    category: ["find", "findBySlug", "findOne", "raw", "stream", "withCookie"],
     writer: ["find", "findOne"],
     "api::writer.editor": ["find", "findOne"],
   });

--- a/shared/tests/mcp-purge.test.js
+++ b/shared/tests/mcp-purge.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+/**
+ * Coverage for content edited through Strapi's MCP tools.
+ *
+ * The content-manager registers MCP tools for create, update, delete, publish,
+ * unpublish and discard_draft. They are worth testing specifically because they
+ * are invisible to the invalidation strategy this plugin used to rely on: an
+ * MCP call is a POST to /mcp, so no content-manager write route is involved and
+ * the hardcoded route list could never have seen it.
+ *
+ * They persist through the content-manager's document-manager service, which
+ * calls strapi.documents(), so the document service middleware added in #129
+ * covers them without knowing MCP exists. These tests drive that service
+ * directly - the same code path the MCP handlers take, without the transport.
+ *
+ * Driving it directly is also currently the only option: MCP cannot be enabled
+ * in this playground at all, because Strapi derives tool names from the API
+ * segment of the uid and this app has two content types in one API, so
+ * registration collides and bootstrap fails. See config/server.js.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/133
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(90000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const UID = "api::article.article";
+
+const documentManager = () =>
+  strapi.plugin("content-manager").service("document-manager");
+
+async function warmArticleCache() {
+  const first = await agent().get("/api/articles");
+  const second = await agent().get("/api/articles");
+
+  expect(first.get("x-cache")).toBe("MISS");
+  expect(second.get("x-cache")).toBe("HIT");
+}
+
+describe("content edited through MCP tools", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => strapi.plugin("rest-cache").service("cacheStore").reset());
+
+  it("purges when an entry is updated", async () => {
+    const [article] = await strapi
+      .documents(UID)
+      .findMany({ status: "published", limit: 1 });
+
+    await warmArticleCache();
+
+    await documentManager().update(article.documentId, UID, {
+      data: { title: "Edited through an MCP tool" },
+    });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when an entry is created", async () => {
+    await warmArticleCache();
+
+    await documentManager().create(UID, {
+      data: {
+        title: "Created through an MCP tool",
+        description: "Created via document-manager",
+        content: "Body copy.",
+        slug: "created-through-mcp",
+      },
+      status: "published",
+    });
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when an entry is published", async () => {
+    const [draft] = await strapi
+      .documents(UID)
+      .findMany({ status: "draft", limit: 1 });
+
+    await warmArticleCache();
+
+    await documentManager().publish(draft.documentId, UID);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("purges when an entry is deleted", async () => {
+    const [article] = await strapi
+      .documents(UID)
+      .findMany({ status: "published", limit: 1 });
+
+    await warmArticleCache();
+
+    await documentManager().delete(article.documentId, UID);
+
+    const after = await agent().get("/api/articles");
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("does not cache the /mcp endpoint itself", async () => {
+    // /mcp writes straight to the socket with ctx.respond = false, so there is
+    // nothing for the cache to store even if a route were configured for it.
+    const keys = await strapi.plugin("rest-cache").service("cacheStore").keys();
+    expect(keys.filter((k) => k.startsWith("/mcp"))).toHaveLength(0);
+  });
+});

--- a/shared/tests/uncacheable-responses.test.js
+++ b/shared/tests/uncacheable-responses.test.js
@@ -1,0 +1,115 @@
+"use strict";
+
+/**
+ * Coverage for responses the cache must refuse to buffer.
+ *
+ * `recv` assumes it can capture ctx.body and replay it later. That assumption
+ * does not hold for every response:
+ *
+ *   - a handler may set `ctx.respond = false` and write to the socket itself,
+ *     in which case ctx.body is meaningless. Strapi's own /mcp route does this.
+ *   - a streamed body is consumed once; storing the stream object caches
+ *     something that cannot be replayed.
+ *   - a response carrying Set-Cookie is specific to one caller and must never
+ *     be served to another.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/133
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(90000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const store = () => strapi.plugin("rest-cache").service("cacheStore");
+
+describe("uncacheable responses", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => store().reset());
+
+  describe("ctx.respond = false", () => {
+    it("serves the raw response intact", async () => {
+      const res = await agent().get("/api/categories/probe/raw");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ raw: true });
+    });
+
+    it("serves it intact on a repeat request", async () => {
+      const first = await agent().get("/api/categories/probe/raw");
+      const second = await agent().get("/api/categories/probe/raw");
+
+      expect(first.body).toEqual({ raw: true });
+      expect(second.body).toEqual({ raw: true });
+    });
+
+    it("does not store anything for it", async () => {
+      await agent().get("/api/categories/probe/raw");
+
+      const keys = await store().keys();
+      expect(keys.filter((k) => k.includes("/categories/probe/raw"))).toHaveLength(0);
+    });
+  });
+
+  describe("streamed body", () => {
+    it("serves the stream intact", async () => {
+      const res = await agent().get("/api/categories/probe/stream");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ streamed: true });
+    });
+
+    it("serves it intact on a repeat request", async () => {
+      await agent().get("/api/categories/probe/stream");
+      const second = await agent().get("/api/categories/probe/stream");
+
+      expect(second.status).toBe(200);
+      expect(second.body).toEqual({ streamed: true });
+    });
+
+    it("does not store the stream", async () => {
+      await agent().get("/api/categories/probe/stream");
+
+      const keys = await store().keys();
+      expect(keys.filter((k) => k.includes("/categories/probe/stream"))).toHaveLength(0);
+    });
+  });
+
+  describe("Set-Cookie", () => {
+    it("does not cache a response carrying a cookie", async () => {
+      await agent().get("/api/categories/probe/with-cookie");
+
+      const keys = await store().keys();
+      expect(keys.filter((k) => k.includes("with-cookie"))).toHaveLength(0);
+    });
+
+    it("gives each caller their own cookie", async () => {
+      const first = await agent().get("/api/categories/probe/with-cookie");
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const second = await agent().get("/api/categories/probe/with-cookie");
+
+      const cookieOf = (res) => String(res.headers["set-cookie"] ?? "");
+
+      expect(cookieOf(first)).not.toBe("");
+      expect(cookieOf(second)).not.toBe("");
+      // A cached response would replay the first caller's cookie to everyone.
+      expect(cookieOf(first)).not.toBe(cookieOf(second));
+    });
+  });
+
+  it("still caches ordinary responses", async () => {
+    const first = await agent().get("/api/categories");
+    const second = await agent().get("/api/categories");
+
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+  });
+});


### PR DESCRIPTION
Closes #133.

`recv` captures `ctx.body` and serves it again later, which assumes the body is a plain serialisable value and that the response isn't specific to the caller who triggered it. Neither holds universally.

## Testing each case corrected the issue's premise

I built fixtures for all three and ran them against the real request path rather than reasoning about it:

| case | reality |
|---|---|
| `ctx.respond = false` | **Already safe.** `/mcp` was never actually broken — when a handler takes over the socket, `ctx.body` is never set, so nothing was stored. Now refused explicitly rather than by accident. |
| **streamed body** | **Genuinely broken.** The stream object was serialised into the cache, and every later request for that key got the corrupted entry. |
| **Set-Cookie** | **Genuinely broken.** The response was cached and replayed, handing one caller's cookie to everyone sharing the key. |

So the headline concern in the issue was the one thing that already worked, and the two real bugs were the ones I'd listed as secondary.

Also honours `Cache-Control: no-store` / `private` so a handler can opt out.

Fixtures live at `/api/categories/probe/*` and are **deliberately configured for caching**, so the refusal is exercised rather than assumed.

## Your MCP question: yes, it busts the cache

Content edited through Strapi's MCP tools invalidates correctly. The content-manager registers create/update/delete/publish/unpublish/discard_draft tools, and they persist through its `document-manager` service, which calls `strapi.documents()` — so the document service middleware from #129 covers them **without knowing MCP exists**.

Worth noting the old route-based invalidation never could have: an MCP call is a `POST /mcp`, so no content-manager write route is involved and the hardcoded list could never have seen it. That's a good validation of the #129 choice — MCP wasn't a consideration when it was made.

`shared/tests/mcp-purge.test.js` drives `document-manager` directly, which is the exact code path the MCP handlers take.

## An upstream Strapi bug, found by the #125 fixture

MCP **cannot be enabled in this playground at all**. `slugifyUidForMcpToolName` returns only the API segment of a uid and discards the content type:

```js
slugifyUidForMcpToolName('api::writer.editor')
  → parts = ['writer', 'editor']
  → namespace === 'api' → return parts[0]   // 'writer'
```

So `api::writer.writer` and `api::writer.editor` both derive `writer`, both try to register `list_writer`, and bootstrap throws:

```
[MCP] tool with name "list_writer" is already registered. Names must be unique.
```

**This takes the whole application down, and affects any Strapi 5.52 app with two content types in one API.** It's the same class of bug as #125 — identity derived from the API name rather than the content type — and it was found by the `api::writer.editor` fixture added to guard that very issue.

`server.mcp.enabled` defaults to `false` with `ENABLE_MCP=true` to reproduce. Worth reporting upstream.

## Verification

90/90 e2e on both providers (up from 76), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)