### PR TITLE
feat: support caching authenticated requests

### DIFF
--- a/packages/plugin-rest-cache/server/src/types/CacheKeysConfig.js
+++ b/packages/plugin-rest-cache/server/src/types/CacheKeysConfig.js
@@ -11,10 +11,23 @@ export class CacheKeysConfig {
    */
   useQueryParams = true;
 
+  /**
+   * Include the authenticated caller's identity in the cache key.
+   *
+   * Only relevant when hitpass is disabled, since the default hitpass never
+   * caches an authenticated request. Without it, two callers authorised for the
+   * same route share one entry.
+   *
+   * @see https://github.com/strapi-community/plugin-rest-cache/issues/113
+   * @type {Boolean}
+   */
+  useAuth = false;
+
   constructor(options = {}) {
-    const { useHeaders = [], useQueryParams = true } = options;
+    const { useHeaders = [], useQueryParams = true, useAuth = false } = options;
     this.useHeaders = useHeaders;
     this.useQueryParams = useQueryParams;
+    this.useAuth = useAuth;
 
     this.useHeaders.sort();
   }

--- a/packages/plugin-rest-cache/server/src/utils/config/resolveUserStrategy.js
+++ b/packages/plugin-rest-cache/server/src/utils/config/resolveUserStrategy.js
@@ -216,6 +216,28 @@ export const resolveUserStrategy = function (strapi, userOptions) {
     }
   }
 
+  // Caching authenticated responses without keying on the caller means two
+  // people authorised for the same route share one entry. Whoever misses first
+  // decides what everybody else sees.
+  //
+  // This is only reachable deliberately - the default hitpass skips anything
+  // carrying an authorization or cookie header - so warn rather than refuse,
+  // but warn loudly and name the content type.
+  // See https://github.com/strapi-community/plugin-rest-cache/issues/113
+  for (const cacheConfig of cacheConfigs) {
+    const cachesAuthenticated = cacheConfig.hitpass === false;
+    const keysAuthIdentity = cacheConfig.keys?.useAuth === true;
+
+    if (cachesAuthenticated && !keysAuthIdentity) {
+      strapi.log.warn(
+        `REST Cache: "${cacheConfig.contentType}" has hitpass disabled but keys.useAuth is not set. ` +
+          'Authenticated responses will be cached under a key that does not identify the caller, ' +
+          'so one user\'s response can be served to another. Set keys: { useAuth: true } for this ' +
+          'contentType, or leave hitpass enabled.'
+      );
+    }
+  }
+
   return deepFreeze(
     new CachePluginStrategy({
       ...userOptions,

--- a/packages/plugin-rest-cache/server/src/utils/keys/generateAuthKey.js
+++ b/packages/plugin-rest-cache/server/src/utils/keys/generateAuthKey.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Identity component of a cache key.
+ *
+ * Cache keys are built from the request path, query and configured headers.
+ * None of that distinguishes one authenticated caller from another, so two
+ * callers who are both authorised for a route - but who should see different
+ * data, because a controller filters on the user or the token's permissions
+ * differ - would share an entry.
+ *
+ * The default hitpass avoids this by never caching an authenticated request at
+ * all. This exists for the case where that is deliberately turned off.
+ *
+ * Nothing derived here may be secret or volatile. `auth.credentials` for a
+ * users-permissions caller is the raw user row, including the password hash and
+ * reset tokens, so it must never be serialised wholesale. An API token's
+ * `lastUsedAt` is rewritten roughly hourly, so including it would silently
+ * invalidate the cache on a timer.
+ *
+ * @see https://github.com/strapi-community/plugin-rest-cache/issues/113
+ *
+ * @param {import('koa').Context} ctx
+ * @return {string}
+ */
+export const generateAuthKey = function (ctx) {
+  const auth = ctx.state?.auth;
+
+  // The route opted out of authentication entirely (config.auth === false), so
+  // there is no identity to key on.
+  if (!auth) {
+    return 'unauthenticated';
+  }
+
+  const strategyName = auth.strategy?.name;
+  const credentials = auth.credentials;
+
+  switch (strategyName) {
+    case 'users-permissions': {
+      // An anonymous caller is authenticated as the public role, which has no
+      // credentials. Everyone in that state sees the same thing, so they can
+      // share one entry.
+      if (!credentials) {
+        return 'up:public';
+      }
+
+      // Keyed per user rather than per role: controllers routinely filter on
+      // ctx.state.user.id, so two users sharing a role can still owe different
+      // responses.
+      return `up:${credentials.id}`;
+    }
+
+    // Renamed from 'api-token' to 'content-api-token' during the 5.x line, so
+    // both are accepted to keep one build working across the supported range.
+    case 'api-token':
+    case 'content-api-token': {
+      // `type` is part of the key because it is editable on an existing token:
+      // downgrading full-access to read-only changes what the same token id is
+      // allowed to see.
+      return `token:${credentials?.id}:${credentials?.type}`;
+    }
+
+    case 'admin':
+    case 'admin-token': {
+      return `admin:${credentials?.id}`;
+    }
+
+    default: {
+      // An unrecognised strategy is treated as its own bucket rather than
+      // shared, so a custom auth strategy cannot silently leak across callers.
+      return strategyName ? `strategy:${strategyName}` : 'unauthenticated';
+    }
+  }
+};

--- a/packages/plugin-rest-cache/server/src/utils/keys/generateCacheKey.js
+++ b/packages/plugin-rest-cache/server/src/utils/keys/generateCacheKey.js
@@ -4,16 +4,19 @@ import { toLower } from 'lodash/fp';
 import path from 'path';
 import { generateHeadersKey } from './generateHeadersKey';
 import { generateQueryParamsKey } from './generateQueryParamsKey';
+import { generateAuthKey } from './generateAuthKey';
 
 export const generateCacheKey = function (
   ctx,
   keys = {
     useQueryParams: false, // @todo: array or boolean => can be optimized
     useHeaders: [],
+    useAuth: false,
   }
 ) {
   let querySuffix = '';
   let headersSuffix = '';
+  let authSuffix = '';
 
   if (keys.useQueryParams !== false) {
     querySuffix = generateQueryParamsKey(ctx, keys.useQueryParams);
@@ -23,10 +26,17 @@ export const generateCacheKey = function (
     headersSuffix = generateHeadersKey(ctx, keys.useHeaders);
   }
 
+  if (keys.useAuth) {
+    // Appended, never prefixed. Purge regexes are anchored on the route path
+    // (`^/api/articles\?`), so anything in front of it would stop matching and
+    // authenticated entries would silently survive every purge.
+    authSuffix = generateAuthKey(ctx);
+  }
+
   const requestPath = toLower(path.posix.normalize(ctx.request.path)).replace(
     /\/$/,
     ''
   );
 
-  return `${requestPath}?${querySuffix}&${headersSuffix}`;
+  return `${requestPath}?${querySuffix}&${headersSuffix}&${authSuffix}`;
 }

--- a/shared/config/cache-strategy.js
+++ b/shared/config/cache-strategy.js
@@ -37,10 +37,13 @@ module.exports = ({ env }) => ({
     {
       contentType: "api::category.category",
       maxAge: 3600000,
+      // Caches authenticated requests, so the caller's identity has to be part
+      // of the key. See https://github.com/strapi-community/plugin-rest-cache/issues/113
       hitpass: false,
       keys: {
         useQueryParams: false,
         useHeaders: ["accept-encoding"],
+        useAuth: env.bool("CATEGORY_USE_AUTH", true),
       },
       routes: [
         // Deliberately configured for caching so the plugin's refusal to cache

--- a/shared/tests/authenticated-caching.test.js
+++ b/shared/tests/authenticated-caching.test.js
@@ -1,0 +1,181 @@
+"use strict";
+
+/**
+ * Coverage for caching authenticated requests.
+ *
+ * The default hitpass never caches a request carrying an authorization or
+ * cookie header, which is safe but means authenticated traffic is never
+ * accelerated. Turning hitpass off makes those responses cacheable - and
+ * without keying on the caller, two people authorised for the same route share
+ * one entry, so whoever misses first decides what everybody else sees.
+ *
+ * `keys: { useAuth: true }` puts the caller's identity in the key.
+ *
+ * api::category.category is configured with hitpass: false and useAuth: true.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/113
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(90000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+const store = () => strapi.plugin("rest-cache").service("cacheStore");
+
+/** Creates a users-permissions user and returns a JWT for them. */
+async function createUser(username) {
+  const role = await strapi
+    .query("plugin::users-permissions.role")
+    .findOne({ where: { type: "authenticated" } });
+
+  const user = await strapi.query("plugin::users-permissions.user").create({
+    data: {
+      username,
+      email: `${username}@example.com`,
+      password: "Password123",
+      confirmed: true,
+      blocked: false,
+      role: role.id,
+      provider: "local",
+    },
+  });
+
+  const jwt = strapi
+    .plugin("users-permissions")
+    .service("jwt")
+    .issue({ id: user.id });
+
+  return { user, jwt };
+}
+
+describe("authenticated caching", () => {
+  let alice;
+  let bob;
+
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+
+    // The authenticated role needs read access for the JWTs to get through.
+    const role = await strapi
+      .query("plugin::users-permissions.role")
+      .findOne({ where: { type: "authenticated" } });
+
+    for (const action of ["api::category.category.find", "api::article.article.find"]) {
+      await strapi.query("plugin::users-permissions.permission").create({
+        data: { action, role: role.id },
+      });
+    }
+
+    alice = await createUser("alice");
+    bob = await createUser("bob");
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => store().reset());
+
+  it("caches an authenticated request when hitpass is disabled", async () => {
+    const first = await agent()
+      .get("/api/categories")
+      .set("Authorization", `Bearer ${alice.jwt}`);
+    const second = await agent()
+      .get("/api/categories")
+      .set("Authorization", `Bearer ${alice.jwt}`);
+
+    expect(first.status).toBe(200);
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+  });
+
+  it("does not serve one user's entry to another", async () => {
+    const forAlice = await agent()
+      .get("/api/categories")
+      .set("Authorization", `Bearer ${alice.jwt}`);
+    const forBob = await agent()
+      .get("/api/categories")
+      .set("Authorization", `Bearer ${bob.jwt}`);
+
+    expect(forAlice.get("x-cache")).toBe("MISS");
+    // Bob must not inherit Alice's entry.
+    expect(forBob.get("x-cache")).toBe("MISS");
+  });
+
+  it("does not serve an authenticated entry to an anonymous caller", async () => {
+    const authed = await agent()
+      .get("/api/categories")
+      .set("Authorization", `Bearer ${alice.jwt}`);
+    const anonymous = await agent().get("/api/categories");
+
+    expect(authed.get("x-cache")).toBe("MISS");
+    expect(anonymous.get("x-cache")).toBe("MISS");
+  });
+
+  it("keys every caller separately in the store", async () => {
+    await agent().get("/api/categories").set("Authorization", `Bearer ${alice.jwt}`);
+    await agent().get("/api/categories").set("Authorization", `Bearer ${bob.jwt}`);
+    await agent().get("/api/categories");
+
+    // ETag is enabled, so each entry has a companion "<key>_etag"; count only
+    // the body keys.
+    const keys = (await store().keys()).filter(
+      (k) => k.startsWith("/api/categories?") && !k.endsWith("_etag")
+    );
+
+    expect(new Set(keys).size).toBe(3);
+    expect(keys.some((k) => k.endsWith(`up:${alice.user.id}`))).toBe(true);
+    expect(keys.some((k) => k.endsWith(`up:${bob.user.id}`))).toBe(true);
+    expect(keys.some((k) => k.endsWith("up:public"))).toBe(true);
+  });
+
+  it("never puts credentials in the key", async () => {
+    await agent().get("/api/categories").set("Authorization", `Bearer ${alice.jwt}`);
+
+    const keys = await store().keys();
+
+    // The users-permissions credentials object is the raw user row, including
+    // the password hash and reset tokens.
+    for (const key of keys) {
+      expect(key).not.toContain("$2a$");
+      expect(key).not.toContain("$2b$");
+      expect(key).not.toContain(alice.user.email);
+      expect(key).not.toContain(alice.jwt);
+    }
+  });
+
+  it("still purges authenticated entries", async () => {
+    await agent().get("/api/categories").set("Authorization", `Bearer ${alice.jwt}`);
+    await agent().get("/api/categories").set("Authorization", `Bearer ${bob.jwt}`);
+
+    const hit = await agent()
+      .get("/api/categories")
+      .set("Authorization", `Bearer ${alice.jwt}`);
+    expect(hit.get("x-cache")).toBe("HIT");
+
+    // Purge regexes are anchored on the route path, so an identity component
+    // placed in front of it would leave these entries permanently stale.
+    const [category] = await strapi
+      .documents("api::category.category")
+      .findMany({ limit: 1 });
+    await strapi.documents("api::category.category").update({
+      documentId: category.documentId,
+      data: { name: "renamed" },
+    });
+
+    const after = await agent()
+      .get("/api/categories")
+      .set("Authorization", `Bearer ${alice.jwt}`);
+    expect(after.get("x-cache")).toBe("MISS");
+  });
+
+  it("leaves content types using the default hitpass uncached", async () => {
+    const first = await agent()
+      .get("/api/articles")
+      .set("Authorization", `Bearer ${alice.jwt}`);
+
+    expect(first.get("x-cache")).toBe("HITPASS");
+  });
+});


### PR DESCRIPTION
Closes #113.

The default `hitpass` skips any request carrying an `authorization` or `cookie` header, so authenticated traffic is never cached. Safe — but it means the cache does nothing for logged-in users, and turning `hitpass` off was **unsafe**: cache keys are built from path, query and configured headers, none of which identify the caller. Two people authorised for the same route shared one entry, and whoever missed first decided what everybody else saw.

## `keys: { useAuth: true }`

| strategy | key component |
|---|---|
| users-permissions | `up:<user id>`, or `up:public` for the public role |
| API tokens | `token:<id>:<type>` |
| admin | `admin:<id>` |
| route with `auth: false` | `unauthenticated` |

**Per user, not per role** — controllers routinely filter on `ctx.state.user.id`, so two users sharing a role can still owe different responses.

**Token type is included** because it's editable: downgrading a token from full-access to read-only changes what the same id may see.

**Both `api-token` and `content-api-token` are accepted** — the strategy was renamed during the 5.x line, and one build has to work across the supported range.

## Nothing secret or volatile in the key

`auth.credentials` for a users-permissions caller is the **raw user row — password hash, reset token, confirmation token**. It is never serialised; only the id is read. There's a test asserting no bcrypt prefix, email or JWT ever appears in a key.

An API token's `lastUsedAt` is rewritten roughly hourly and is deliberately excluded — including it would invalidate the cache on a timer.

## A trap avoided

My first implementation **prefixed** the key with the identity. Purge regexes are anchored on the route path (`^/api/articles\?`), so that would have stopped them matching and left every authenticated entry permanently stale — silently, and only for authenticated users.

Same shape as the key-prefix bug in #131. The identity is appended instead, and there's a test that authenticated entries still purge.

## Guard for the actual footgun

Warns at register time when a contentType disables `hitpass` without setting `keys.useAuth`, naming the contentType. That combination is the unsafe one, and it's only reachable deliberately — so a warning is right, not a refusal.

## Tests

Alice and Bob get separate entries; an authenticated entry is never served anonymously; three callers produce three distinct keys; credentials never leak into keys; purging still reaches authenticated entries; content types using the default hitpass still report HITPASS.

97/97 e2e on both providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)