### PR TITLE
test: guard the custom field plugin ordering from #119

### DIFF
--- a/playgrounds/memory/config/plugins.js
+++ b/playgrounds/memory/config/plugins.js
@@ -1,6 +1,9 @@
 "use strict";
 
 module.exports = ({ env }) => ({
+  // Deliberately declared AFTER rest-cache below, reproducing the plugin
+  // ordering reported in
+  // https://github.com/strapi-community/plugin-rest-cache/issues/119
   "rest-cache": {
     enabled: env.bool("ENABLE_CACHE", true),
     config: {
@@ -19,5 +22,9 @@ module.exports = ({ env }) => ({
     config: {
       jwtSecret: env("JWT_SECRET", "b46375d2efd1c69d8efcdcb46d3acd67a"),
     },
+  },
+  "colour-field": {
+    enabled: true,
+    resolve: "./src/plugins/colour-field",
   },
 });

--- a/playgrounds/redis/config/plugins.js
+++ b/playgrounds/redis/config/plugins.js
@@ -1,6 +1,9 @@
 "use strict";
 
 module.exports = ({ env }) => ({
+  // Deliberately declared AFTER rest-cache below, reproducing the plugin
+  // ordering reported in
+  // https://github.com/strapi-community/plugin-rest-cache/issues/119
   redis: {
     config: {
       debug: true,
@@ -53,5 +56,9 @@ module.exports = ({ env }) => ({
     config: {
       jwtSecret: env("JWT_SECRET", "b46375d2efd1c69d8efcdcb46d3acd67a"),
     },
+  },
+  "colour-field": {
+    enabled: true,
+    resolve: "./src/plugins/colour-field",
   },
 });

--- a/shared/src/api/category/content-types/category/schema.json
+++ b/shared/src/api/category/content-types/category/schema.json
@@ -26,6 +26,10 @@
       "relation": "oneToMany",
       "target": "api::article.article",
       "mappedBy": "category"
+    },
+    "accent": {
+      "type": "string",
+      "customField": "plugin::colour-field.colour"
     }
   }
 }

--- a/shared/src/plugins/colour-field/package.json
+++ b/shared/src/plugins/colour-field/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "colour-field",
+  "version": "0.0.0",
+  "strapi": {
+    "kind": "plugin",
+    "name": "colour-field",
+    "displayName": "Colour Field",
+    "description": "Registers a custom field, to exercise plugin load ordering"
+  }
+}

--- a/shared/src/plugins/colour-field/strapi-server.js
+++ b/shared/src/plugins/colour-field/strapi-server.js
@@ -1,0 +1,19 @@
+"use strict";
+
+/**
+ * A local plugin whose only job is to register a custom field.
+ *
+ * Reproduces the shape reported in
+ * https://github.com/strapi-community/plugin-rest-cache/issues/119: a content
+ * type references a custom field owned by a plugin, and rest-cache is listed
+ * *before* that plugin, so it registers first.
+ */
+module.exports = {
+  register({ strapi }) {
+    strapi.customFields.register({
+      name: "colour",
+      plugin: "colour-field",
+      type: "string",
+    });
+  },
+};

--- a/shared/tests/custom-fields.test.js
+++ b/shared/tests/custom-fields.test.js
@@ -1,0 +1,59 @@
+"use strict";
+
+/**
+ * Guard for plugin load ordering against custom fields.
+ *
+ * #119 reported that a content type using a custom field owned by another
+ * plugin would fail at startup with "Could not find Custom Field", depending on
+ * plugin order, because rest-cache reads strapi.apis during register() to
+ * inject its route middleware.
+ *
+ * The playground reproduces that arrangement permanently: a local plugin owns
+ * the custom field, a cached content type uses it, and rest-cache is declared
+ * first in config/plugins.js. If reading strapi.apis during register ever
+ * starts validating custom fields again, this suite stops booting.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/119
+ */
+
+const { setup, teardown, agent } = require("./helpers/strapi");
+
+jest.setTimeout(90000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+describe("custom fields and plugin load order", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  it("boots with a plugin-owned custom field on a cached content type", () => {
+    const attribute =
+      strapi.contentType("api::category.category").attributes.accent;
+
+    expect(attribute.customField).toBe("plugin::colour-field.colour");
+  });
+
+  it("loads the plugin that owns the custom field", () => {
+    // On 5.52 strapi.customFields exposes only register() - the throwing get()
+    // that produced "Could not find Custom Field" is no longer reachable from
+    // anywhere in Strapi, which is a large part of why #119 no longer
+    // reproduces. So assert the owning plugin loaded rather than introspecting
+    // a registry whose read API has changed.
+    expect(strapi.plugin("colour-field")).toBeDefined();
+  });
+
+  it("still caches the content type using it", async () => {
+    await strapi.plugin("rest-cache").service("cacheStore").reset();
+
+    const first = await agent().get("/api/categories");
+    const second = await agent().get("/api/categories");
+
+    expect(first.get("x-cache")).toBe("MISS");
+    expect(second.get("x-cache")).toBe("HIT");
+  });
+});


### PR DESCRIPTION
Relates to #119.

## It doesn't reproduce on Strapi 5.52.0

#119 reports that a content type using a custom field owned by another plugin fails at startup with `Could not find Custom Field`, depending on plugin order, because rest-cache reads `strapi.apis` during `register()` to inject its route middleware.

I built the reported arrangement exactly and it boots cleanly:

- a local plugin (`colour-field`) owns the custom field
- the **cached** `api::category.category` uses it
- **rest-cache is declared before that plugin** in `config/plugins.js` — the ordering users reported as broken

## Why it no longer happens

Two independent pieces of evidence:

1. **Nothing calls the getter that raises that error.** `customFields.get()` throws `Could not find Custom Field`, and grepping installed 5.52 *and* Strapi's develop branch finds no caller anywhere. It's unreachable code.
2. **`strapi.customFields` exposes only `register()`** on 5.52 — no `get`, no `getAll`. The entire read API that performed the validation is gone.

So the fix is upstream, not here. I'd rather report that with evidence than write a speculative workaround for something that can't fire.

## What I nearly did instead

My first instinct was to move the injection out of `register()`, and I'd suggested that earlier in the thread. Checking the ordering showed it wouldn't work: `initRouting()` runs at `Strapi.ts:516`, **before** `runPluginsLifecycles(BOOTSTRAP)` at 519 — so injecting during plugin bootstrap is too late, the routes are already composed.

There *is* a viable window (`strapi::content-types.afterSync`, which fires after every plugin registers but before routing). Worth remembering if this ever returns — but not worth restructuring for a bug that no longer exists.

## What this PR does

Keeps the arrangement as a permanent fixture, plus three assertions. If reading `strapi.apis` during register ever starts validating custom fields again, **this suite stops booting** — rather than the bug returning quietly for the users who reported it.

No production change. 105/105 e2e on both providers.

Suggest closing #119 once this lands, inviting the reporters to reopen if they still see it on 5.52+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)