### PR TITLE
feat: add a cache statistics endpoint for the admin dashboard

### DIFF
--- a/packages/plugin-rest-cache/server/src/controllers/config.js
+++ b/packages/plugin-rest-cache/server/src/controllers/config.js
@@ -24,5 +24,13 @@ export default function createConfigController({ strapi }) {
       const { provider } = strapi.config.get("plugin::rest-cache");
       ctx.body = { provider };
     },
+    /**
+     * Snapshot of what the cache currently holds, for the admin dashboard.
+     *
+     * @param {Context} ctx
+     */
+    async stats(ctx) {
+      ctx.body = await strapi.plugin('rest-cache').service('cacheStats').summary();
+    },
   };
 }

--- a/packages/plugin-rest-cache/server/src/routes/admin/config.js
+++ b/packages/plugin-rest-cache/server/src/routes/admin/config.js
@@ -19,6 +19,20 @@ export default [
   },
   {
     method: 'GET',
+    path: '/stats',
+    handler: 'config.stats',
+    config: {
+      policies: [
+        'admin::isAuthenticatedAdmin',
+        {
+          name: 'plugin::content-manager.hasPermissions',
+          config: { actions: [`plugin::${pluginId}.cache.read-strategy`] },
+        },
+      ],
+    },
+  },
+  {
+    method: 'GET',
     path: '/config/provider',
     handler: 'config.provider',
     config: {

--- a/packages/plugin-rest-cache/server/src/services/cacheStats.js
+++ b/packages/plugin-rest-cache/server/src/services/cacheStats.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * @typedef {import('@strapi/strapi').Strapi} Strapi
+ */
+
+/**
+ * Introspection for the admin dashboard.
+ *
+ * Counts are derived from the store's own key list rather than tracked
+ * separately, so they cannot drift from reality. That does mean a call costs
+ * one enumeration - cheap on redis since #131 made it a single SMEMBERS, but
+ * still not something to poll aggressively.
+ *
+ * @see https://github.com/strapi-community/plugin-rest-cache/issues/114
+ *
+ * @param {{ strapi: Strapi }} strapi
+ */
+export default function createCacheStatsService({ strapi }) {
+  return {
+    /**
+     * A snapshot of what the cache currently holds, grouped by content type.
+     *
+     * @return {Promise<object>}
+     */
+    async summary() {
+      const { provider, strategy } = strapi.config.get('plugin::rest-cache');
+      const cacheConfig = strapi.plugin('rest-cache').service('cacheConfig');
+      const cacheStore = strapi.plugin('rest-cache').service('cacheStore');
+
+      const keys = (await cacheStore.keys()) ?? [];
+
+      // ETag entries are companions to a body entry, not cache entries in their
+      // own right. Counting them would double every number on the dashboard.
+      const entryKeys = keys.filter((key) => !key.endsWith('_etag'));
+      const etagCount = keys.length - entryKeys.length;
+
+      const contentTypes = cacheConfig.getUids().map((uid) => {
+        const conf = cacheConfig.get(uid);
+        const regExps = cacheConfig.getCacheKeysRegexp(uid, {}, true);
+        const matched = entryKeys.filter((key) => regExps.some((r) => r.test(key)));
+
+        return {
+          uid,
+          entries: matched.length,
+          maxAge: conf?.maxAge,
+          hitpass: conf?.hitpass !== false,
+          keysAuthIdentity: conf?.keys?.useAuth === true,
+          routes: (conf?.routes ?? [])
+            .filter((route) => route.method === 'GET')
+            .map((route) => route.path),
+          relatedContentTypes: cacheConfig.getRelatedCachedUid(uid),
+        };
+      });
+
+      // A key can match more than one content type's routes, and a route may
+      // have no configured content type at all, so this is deliberately the
+      // total rather than the sum of the per-type counts.
+      return {
+        provider: { name: provider?.name },
+        strategy: {
+          enableEtag: strategy.enableEtag,
+          enableXCacheHeaders: strategy.enableXCacheHeaders,
+          enableDocumentServiceMiddleware: strategy.enableDocumentServiceMiddleware,
+          clearRelatedCache: strategy.clearRelatedCache,
+          keysPrefix: strategy.keysPrefix,
+          maxAge: strategy.maxAge,
+        },
+        totals: {
+          entries: entryKeys.length,
+          etags: etagCount,
+          contentTypes: contentTypes.length,
+        },
+        contentTypes,
+      };
+    },
+  };
+}

--- a/packages/plugin-rest-cache/server/src/services/index.js
+++ b/packages/plugin-rest-cache/server/src/services/index.js
@@ -2,8 +2,10 @@
 
 import cacheConfig from './cacheConfig';
 import cacheStore from './cacheStore';
+import cacheStats from './cacheStats';
 
 export default {
   cacheConfig,
   cacheStore,
+  cacheStats,
 };

--- a/shared/tests/cache-stats.test.js
+++ b/shared/tests/cache-stats.test.js
@@ -1,0 +1,98 @@
+"use strict";
+
+/**
+ * Coverage for the cache statistics endpoint backing the admin dashboard.
+ *
+ * See https://github.com/strapi-community/plugin-rest-cache/issues/114
+ */
+
+const { setup, teardown, agent, adminAgent } = require("./helpers/strapi");
+
+jest.setTimeout(90000);
+
+process.env.STRAPI_DISABLE_UPDATE_NOTIFICATION = true;
+process.env.STRAPI_HIDE_STARTUP_MESSAGE = true;
+process.env.STRAPI_TELEMETRY_DISABLED = true;
+
+describe("cache stats", () => {
+  beforeAll(async () => {
+    process.env.KEYS_PREFIX = undefined;
+    await setup();
+  });
+  afterAll(async () => await teardown());
+
+  beforeEach(() => strapi.plugin("rest-cache").service("cacheStore").reset());
+
+  it("requires authentication", async () => {
+    const res = await agent().get("/rest-cache/stats");
+    expect(res.status).toBe(401);
+  });
+
+  it("reports the provider and strategy", async () => {
+    const res = await adminAgent().get("/rest-cache/stats");
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.provider.name).toBe("string");
+    expect(res.body.strategy).toHaveProperty("enableDocumentServiceMiddleware");
+    expect(res.body.strategy).toHaveProperty("clearRelatedCache");
+  });
+
+  it("reports zero entries for an empty cache", async () => {
+    const res = await adminAgent().get("/rest-cache/stats");
+
+    expect(res.body.totals.entries).toBe(0);
+    expect(res.body.totals.contentTypes).toBeGreaterThan(0);
+  });
+
+  it("counts entries per content type", async () => {
+    await agent().get("/api/articles");
+    await agent().get("/api/homepage");
+
+    const res = await adminAgent().get("/rest-cache/stats");
+
+    const article = res.body.contentTypes.find(
+      (c) => c.uid === "api::article.article"
+    );
+    const homepage = res.body.contentTypes.find(
+      (c) => c.uid === "api::homepage.homepage"
+    );
+
+    expect(article.entries).toBeGreaterThan(0);
+    expect(homepage.entries).toBeGreaterThan(0);
+  });
+
+  it("does not count etag companions as entries", async () => {
+    await agent().get("/api/articles");
+
+    const res = await adminAgent().get("/rest-cache/stats");
+    const keys = await strapi.plugin("rest-cache").service("cacheStore").keys();
+
+    // ETag is enabled in the playground, so the raw key count is double.
+    expect(res.body.totals.etags).toBeGreaterThan(0);
+    expect(res.body.totals.entries + res.body.totals.etags).toBe(keys.length);
+  });
+
+  it("surfaces per-content-type configuration", async () => {
+    const res = await adminAgent().get("/rest-cache/stats");
+
+    const category = res.body.contentTypes.find(
+      (c) => c.uid === "api::category.category"
+    );
+
+    // category is the one configured with hitpass off and identity keying.
+    expect(category.hitpass).toBe(false);
+    expect(category.keysAuthIdentity).toBe(true);
+    expect(category.routes).toContain("/api/categories");
+  });
+
+  it("reflects a purge", async () => {
+    await agent().get("/api/articles");
+    const before = await adminAgent().get("/rest-cache/stats");
+    expect(before.body.totals.entries).toBeGreaterThan(0);
+
+    await strapi.plugin("rest-cache").service("cacheStore").reset();
+
+    const after = await adminAgent().get("/rest-cache/stats");
+    expect(after.body.totals.entries).toBe(0);
+  });
+});


### PR DESCRIPTION
Part of #114 — **server side only**. See the last section for why the UI isn't here.

## `GET /rest-cache/stats`

| field | contents |
|---|---|
| `provider` | name of the active provider |
| `strategy` | the flags that change caching behaviour |
| `totals` | entries, etags, configured content types |
| `contentTypes` | per uid: entry count, `maxAge`, whether hitpass is active, whether keys include caller identity, cached GET routes, and the related content types a write would also purge |

Counts are **derived from the store's own key list** rather than tracked separately, so they can't drift from what's actually cached. That costs one enumeration per call — a single `SMEMBERS` on redis since #131 — so it's cheap but not something to poll aggressively.

ETag entries are excluded from the entry count and reported separately. Counting them would **double every number on the dashboard**, since each cached body has a companion `<key>_etag`. There's a test asserting `entries + etags === total keys`.

## Why the UI isn't in this PR

Two things I found while starting it:

1. **The existing admin scaffolding is dead.** `pages/App` and `pages/HomePage` are unreachable — no menu or settings link is ever registered — and `App` imports `Switch`/`Route` from **react-router-dom v5** while the plugin depends on **v6**, so it would throw if it ever rendered. The dashboard needs that replaced, not extended.
2. **I couldn't reliably enumerate `@strapi/design-system` v2's exports** from this environment, and I can't render the admin to check the result.

Writing a React dashboard against a component library I can't verify, and shipping it untested, is how plausible-looking but broken UI gets merged. I'd rather land the server half — which is complete and covered by 7 tests — and leave #114 open for the UI with the groundwork done.

Whoever picks it up should know the dead `App`/`HomePage` pair needs deleting rather than editing.

## Verification

112/112 e2e on both providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)