### PR TITLE
ci: stop dependabot offering majors we cannot take

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,27 @@ updates:
       - dependency-name: "quick-lru"
         update-types: ["version-update:semver-major"]
 
+      # These are governed by Strapi's peer range, not by us. As of 5.52.0:
+      #   react, react-dom     ^17.0.0 || ^18.0.0
+      #   react-router-dom     ^6.30.3
+      # Offering a major only produces a PR that cannot be merged until Strapi
+      # widens its own range.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router-dom"
+        update-types: ["version-update:semver-major"]
+
+      # @keyv/redis 5 swaps ioredis for @redis/client. The redis provider
+      # relies on that adapter's internals - _getNamespace(), namespace,
+      # opts.useRedisSets and the SADD/SREM tracking set - which is what makes
+      # the single-SMEMBERS enumeration in #131 and the cluster handling in
+      # #100 work. That upgrade needs its own branch with the provider tests
+      # and cluster check run against it, not a batched bump.
+      - dependency-name: "@keyv/redis"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Follow-up to #161, prompted by what it produced.

The corrected grouping worked — #163 arrived as **nine production dependencies in one reviewable PR** instead of nine separate ones. Reviewing them together made it immediately obvious that several can't be merged at all, which is exactly the value of grouping majors.

## Governed by Strapi's peer range, not by us

Strapi 5.52.0 declares:

```json
"react": "^17.0.0 || ^18.0.0",
"react-dom": "^17.0.0 || ^18.0.0",
"react-router-dom": "^6.30.3"
```

So `react` 19 and `react-router-dom` 7 are unmergeable until Strapi widens its own range. Offering them only generates PRs that can be closed and nothing else.

## Needs its own branch

`@keyv/redis` 5 **swaps ioredis for `@redis/client`**. The redis provider deliberately uses that adapter's internals — `_getNamespace()`, `namespace`, `opts.useRedisSets` and the SADD/SREM tracking set — which is precisely what makes the single-`SMEMBERS` enumeration in #131 and the cluster handling in #100 work.

A major there could move or remove all of it. It needs the provider tests and the cluster check run against it deliberately, not folded into a batch of unrelated bumps.

## Not ignored

`immer`, `mime-types`, `fs-extra`, `better-sqlite3` majors still come through — they're reviewable on their own merits. `quick-lru` majors stay ignored for the reason in #128 (v5 lacks the iterator keyv needs, which would silently break all invalidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)