### PR TITLE
chore: prepare for the pending dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -110,6 +110,17 @@ updates:
       - dependency-name: "@keyv/redis"
         update-types: ["version-update:semver-major"]
 
+      # react-intl is governed by the admin runtime, not by us. The plugin peers
+      # on ^6.0.0 and @strapi/admin bundles 6.6.2, so a major only produces an
+      # unmergeable PR - the same situation as react and react-router-dom above.
+      - dependency-name: "react-intl"
+        update-types: ["version-update:semver-major"]
+
+      # jest majors are already ignored, so jest-cli must be too. Letting it
+      # advance alone pairs jest-cli 30 with jest 29.
+      - dependency-name: "jest-cli"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/packages/plugin-rest-cache/admin/src/hooks/useCacheStrategy/reducer.js
+++ b/packages/plugin-rest-cache/admin/src/hooks/useCacheStrategy/reducer.js
@@ -1,5 +1,5 @@
 /* eslint-disable consistent-return */
-import produce from 'immer';
+import { produce } from 'immer';
 
 export const initialState = {
   strategy: {},

--- a/playgrounds/memory/package.json
+++ b/playgrounds/memory/package.json
@@ -15,7 +15,6 @@
     "@strapi/plugin-users-permissions": "5.52.0",
     "@strapi/strapi": "5.52.0",
     "better-sqlite3": "12.11.1",
-    "fs-extra": "^10.0.0",
     "mime-types": "^2.1.27",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/playgrounds/redis/package.json
+++ b/playgrounds/redis/package.json
@@ -18,7 +18,6 @@
     "@strapi-community/plugin-rest-cache": "workspace:*",
     "@strapi-community/provider-rest-cache-redis": "workspace:*",
     "better-sqlite3": "12.11.1",
-    "fs-extra": "^10.0.0",
     "mime-types": "^2.1.27",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,9 +189,6 @@ importers:
       better-sqlite3:
         specifier: 12.11.1
         version: 12.11.1
-      fs-extra:
-        specifier: ^10.0.0
-        version: 10.1.0
       mime-types:
         specifier: ^2.1.27
         version: 2.1.35
@@ -244,9 +241,6 @@ importers:
       better-sqlite3:
         specifier: 12.11.1
         version: 12.11.1
-      fs-extra:
-        specifier: ^10.0.0
-        version: 10.1.0
       mime-types:
         specifier: ^2.1.27
         version: 2.1.35


### PR DESCRIPTION
Three changes, each unblocking or preventing one of the open dependabot PRs.

## immer 11 would have shipped a broken admin

`immer` 11 **removes the default export**, and the admin does `import produce from 'immer'`:

```
immer  9 ESM: default = function                    <- works today
immer 11 ESM: default = undefined, produce = function
```

So `produce` would be `undefined` and throw the moment the cache-strategy hook ran.

**CI would not have caught this.** The e2e suite never renders the admin panel, so the production-dependencies bump in #174 would have merged green and broken the panel at runtime for users.

The named import works on both 9 and 11, so this is safe now and makes that bump safe later.

I checked this specifically because of the `lodash` incident earlier in this work — I removed it believing it unused, and yarn's hoisting hid the mistake. Reading a version table isn't verification.

## fs-extra removed rather than upgraded

Declared by both playgrounds, imported nowhere. Confirmed with `git grep` across every tracked file — the only occurrences were the two `package.json` entries. #174 proposed bumping it 10 → 11.

## Two more dependabot ignores

| package | why |
|---|---|
| `react-intl` | Governed by the admin runtime, not us. The plugin peers on `^6.0.0` and `@strapi/admin` bundles `6.6.2`, so a major is unmergeable — same as `react`/`react-router-dom`. |
| `jest-cli` | `jest` majors are already ignored, so this must be too. Letting it advance alone pairs `jest-cli` 30 with `jest` 29. |

## What this leaves

- **#162** (dev-tooling) can be closed — its linters fail on all three Node versions, and it carries both `react-intl` 10 and `jest-cli` 30. It'll regenerate without them. The remaining `prettier` 2→3 / `eslint` 8→10 bumps are a deliberate reformatting job, not a rubber-stamp.
- **#174** (production) becomes safe once this lands: `immer` 11 has a compatible import, `fs-extra` is gone, `mime-types` 3 I verified keeps `lookup()` working for the playground seeding, and `quick-lru` 7.0.1→7.3.0 is a patch within the line we deliberately stay on.

112/112 e2e on both providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)