### PR TITLE
fix(admin): make the panel work in a production build, and add browser tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,41 @@ jobs:
         working-directory: playgrounds/memory
         run: pnpm run test:e2e
 
+  # Browser coverage for the admin panel. The jest suites boot Strapi in-process
+  # and never render anything, which is how the panel stayed broken for the
+  # whole Strapi 5 line without a red build.
+  #
+  # One Node version only: this builds the admin panel, which is minutes, and
+  # what it guards is browser behaviour rather than anything Node-version
+  # specific.
+  e2e_admin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - run: pnpm run build:plugin:rest-cache
+
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run admin panel e2e tests
+        run: pnpm run test:admin
+
+      - if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-output
+          path: e2e/.output/
+          retention-days: 7
+
   e2e_redis:
     runs-on: ubuntu-latest
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,8 @@ build
 playgrounds/**/types/*
 # Playwright MCP scratch output
 .playwright-mcp/
+
+# Playwright
+e2e/.auth/
+e2e/.output/
+e2e/playwright-report/

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,61 @@
+import { chromium, request, type FullConfig } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The repository root is `"type": "module"`, so there is no __dirname here.
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const ADMIN = {
+  email: 'admin@strapi.io',
+  firstname: 'admin',
+  lastname: 'admin',
+  password: 'Password123',
+};
+
+const AUTH_STATE = resolve(HERE, '.auth/admin.json');
+
+/**
+ * Create the first admin, log in once, and save the session.
+ *
+ * Every spec reuses the saved state rather than logging in again: the login
+ * form is Strapi's, not ours, and re-driving it per test buys nothing but
+ * runtime.
+ */
+export default async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0].use.baseURL!;
+
+  const api = await request.newContext({ baseURL });
+
+  // Idempotent: the playground database persists between runs locally, so on
+  // the second run the admin already exists and this returns 400.
+  await api.post('/admin/register-admin', { data: ADMIN }).catch(() => undefined);
+
+  // Give the dashboard something to show. Without this the cache is empty and
+  // every count is zero, which is indistinguishable from the stats endpoint
+  // being broken.
+  for (const route of ['/api/articles', '/api/homepage', '/api/global']) {
+    await api.get(route).catch(() => undefined);
+  }
+
+  await api.dispose();
+
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ baseURL });
+
+  await page.goto('/admin/auth/login');
+  // By name rather than by label: the password field sits next to a "Show
+  // password" toggle, so an accessible-name lookup for "Password" is
+  // ambiguous.
+  await page.locator('input[name="email"]').fill(ADMIN.email);
+  await page.locator('input[name="password"]').fill(ADMIN.password);
+  await page.locator('button[type="submit"]').click();
+
+  // Landing on the homepage is what proves the credentials took.
+  await page.waitForURL('**/admin', { timeout: 60_000 });
+
+  mkdirSync(dirname(AUTH_STATE), { recursive: true });
+  await page.context().storageState({ path: AUTH_STATE });
+
+  await browser.close();
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,43 @@
+import { request, type Page } from '@playwright/test';
+
+/**
+ * Warm the cache through the public API.
+ *
+ * Deliberately NOT `page.request`: that shares the browser context, so it
+ * sends the admin session cookie - and the plugin's default hitpass bypasses
+ * the cache for any request carrying an authorization or cookie header. The
+ * requests would succeed, cache nothing, and leave every count at zero.
+ */
+export async function warmCache(baseURL: string) {
+  const anonymous = await request.newContext({ baseURL, storageState: undefined });
+
+  for (const route of ['/api/articles', '/api/homepage', '/api/global']) {
+    await anonymous.get(route);
+  }
+
+  await anonymous.dispose();
+}
+
+/**
+ * Open an existing article's edit view.
+ *
+ * Resolves the documentId over the API and navigates straight there rather
+ * than clicking a row in the list: the list's action bar overlays the row
+ * links, so the click is intercepted and times out.
+ */
+export async function openFirstArticle(page: Page, baseURL: string) {
+  const anonymous = await request.newContext({ baseURL, storageState: undefined });
+  const response = await anonymous.get('/api/articles');
+  const body = (await response.json()) as { data: Array<{ documentId: string }> };
+  await anonymous.dispose();
+
+  const [article] = body.data;
+
+  if (!article) {
+    throw new Error('The playground has no articles to open.');
+  }
+
+  await page.goto(
+    `/admin/content-manager/collection-types/api::article.article/${article.documentId}`
+  );
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,65 @@
+import { defineConfig, devices } from '@playwright/test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// testDir and globalSetup are resolved against this file, but `use.storageState`
+// is resolved against the working directory - so it has to be absolute, or the
+// suite only runs when invoked from e2e/.
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Browser coverage for the admin panel.
+ *
+ * The jest suites under shared/tests boot Strapi in-process and exercise the
+ * HTTP API. They cannot see the admin panel at all, which is how the panel
+ * came to be broken for the whole Strapi 5 line without a single red build:
+ * it declared react-router v5 routes against v6, registered no route to its
+ * own page, and shipped an empty translation file. Every one of those is
+ * invisible to a test that never renders anything.
+ *
+ * These tests boot the memory playground for real, build its admin, and drive
+ * it in a browser.
+ */
+
+const PORT = Number(process.env.E2E_PORT ?? 1337);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests',
+  outputDir: './.output',
+
+  // The admin panel is a single shared instance with one seeded database, and
+  // the tests purge and warm the cache. Running them in parallel would have
+  // them clearing each other's entries.
+  fullyParallel: false,
+  workers: 1,
+
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+
+  globalSetup: './global-setup.ts',
+
+  use: {
+    baseURL: BASE_URL,
+    // Written by global-setup after logging in once.
+    storageState: resolve(HERE, '.auth/admin.json'),
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+
+  webServer: {
+    // `build` then `start`, not `develop`: develop compiles the admin lazily on
+    // first request, so the first test races the bundler. This also exercises
+    // the production admin build, which is what users actually run.
+    command: 'pnpm --filter @strapi-plugin-rest-cache/playground-memory run e2e:serve',
+    url: `${BASE_URL}/admin`,
+    reuseExistingServer: !process.env.CI,
+    // A cold admin build is slow, and slower again on a CI runner.
+    timeout: 15 * 60 * 1000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/e2e/tests/admin-panel.spec.ts
+++ b/e2e/tests/admin-panel.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * The panel mounts at all.
+ *
+ * This is the cheapest and most valuable assertion in the suite. A plugin's
+ * `register` runs inside the admin's own bootstrap, so anything that throws
+ * there does not degrade to "my plugin is missing" - it aborts the render and
+ * leaves an empty #strapi div with no console error.
+ *
+ * That is not hypothetical: `Widgets.checkWidgets` asserts `widget.icon` with
+ * `invariant` even though `WidgetArgs` types it optional, so registering a
+ * widget without an icon took down the entire administration panel. Every HTTP
+ * test still passed, because the server was fine.
+ */
+test.describe('admin panel', () => {
+  test('renders with the plugin registered', async ({ page }) => {
+    await page.goto('/admin');
+
+    // React actually mounted, rather than serving the shell and dying.
+    await expect(page.locator('#strapi')).not.toBeEmpty();
+    await expect(page.getByRole('heading', { name: /hello/i })).toBeVisible();
+  });
+
+  test('lists the plugin in the settings navigation', async ({ page }) => {
+    await page.goto('/admin/settings');
+
+    const nav = page.getByRole('navigation', { name: 'Settings' });
+    await expect(nav.getByText('REST Cache', { exact: true })).toBeVisible();
+  });
+});

--- a/e2e/tests/content-manager.spec.ts
+++ b/e2e/tests/content-manager.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+import { openFirstArticle } from '../helpers';
+
+const ARTICLES = '/admin/content-manager/collection-types/api::article.article';
+
+test.describe('content-manager integration', () => {
+  test('shows the cache panel on the edit view', async ({ page, baseURL }) => {
+    await openFirstArticle(page, baseURL!);
+
+    // The panel used to render an empty body under a hardcoded English title,
+    // so assert on the sentence that makes it useful rather than the title.
+    await expect(page.getByText(/cached for up to/i)).toBeVisible();
+    await expect(page.getByText(/cached for up to 1h/i)).toBeVisible();
+  });
+
+  test('offers the purge action in the document actions menu', async ({ page, baseURL }) => {
+    await openFirstArticle(page, baseURL!);
+
+    // The entry-level menu, not the page-level one.
+    await page
+      .getByRole('button', { name: /more (document )?actions/i })
+      .last()
+      .click();
+
+    await expect(
+      page.getByRole('menuitem', { name: 'Purge REST Cache' })
+    ).toBeVisible();
+  });
+
+  test('offers the purge button on the list view', async ({ page, baseURL }) => {
+    await page.goto(ARTICLES);
+
+    await expect(page.getByRole('button', { name: 'Purge REST Cache' })).toBeVisible();
+  });
+
+  test('leaves an uncached content type alone', async ({ page, baseURL }) => {
+    // api::user is not in the configured strategy, so neither the panel nor
+    // the action should appear. A contribution that renders unconditionally
+    // would tell editors their content is cached when it is not.
+    await page.goto('/admin/content-manager/collection-types/plugin::users-permissions.user');
+
+    await expect(page.getByText(/cached for up to/i)).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Purge REST Cache' })).toHaveCount(0);
+  });
+});

--- a/e2e/tests/homepage-widget.spec.ts
+++ b/e2e/tests/homepage-widget.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+import { warmCache } from '../helpers';
+
+test.describe('homepage widget', () => {
+  test('reports what the cache holds', async ({ page, baseURL }) => {
+    await warmCache(baseURL!);
+
+    await page.goto('/admin');
+
+    const widget = page
+      .locator('div')
+      .filter({ hasText: /^REST Cache/ })
+      .first();
+
+    await expect(widget).toBeVisible();
+
+    // The count is pluralised through ICU, so this also proves the message
+    // format and the translation file are wired up rather than falling back
+    // to a raw message id.
+    await expect(page.getByText(/\d+ (entry|entries) cached/)).toBeVisible();
+    await expect(page.getByText(/via memory/)).toBeVisible();
+  });
+
+  test('links to the settings page', async ({ page, baseURL }) => {
+    await page.goto('/admin');
+
+    await page.getByRole('link', { name: 'Open REST Cache' }).click();
+
+    await page.waitForURL('**/admin/settings/rest-cache');
+    await expect(page.getByRole('heading', { name: 'REST Cache' })).toBeVisible();
+  });
+});

--- a/e2e/tests/settings-dashboard.spec.ts
+++ b/e2e/tests/settings-dashboard.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from '@playwright/test';
+
+import { warmCache } from '../helpers';
+
+const DASHBOARD = '/admin/settings/rest-cache';
+
+/** The row for a content type in the "Cached content types" table. */
+const rowFor = (page: Page, uid: string) =>
+  page.getByRole('row').filter({ hasText: uid });
+
+test.describe('settings dashboard', () => {
+  test('shows the cache overview', async ({ page, baseURL }) => {
+    await warmCache(baseURL!);
+    await page.goto(DASHBOARD);
+
+    await expect(page.getByRole('heading', { name: 'REST Cache' })).toBeVisible();
+
+    // The four headline figures. `.first()` because "Cached content types" is
+    // also the heading of the table further down the page.
+    for (const label of [
+      'Cached entries',
+      'Stored ETags',
+      'Cached content types',
+      'Provider',
+    ]) {
+      await expect(page.getByText(label, { exact: true }).first()).toBeVisible();
+    }
+
+    // The provider name is read from the running server, so this also proves
+    // the stats endpoint is reachable and shaped as the page expects.
+    await expect(page.getByText('memory', { exact: true })).toBeVisible();
+  });
+
+  test('gives every stat card the same height', async ({ page, baseURL }) => {
+    await page.goto(DASHBOARD);
+
+    const labels = ['Cached entries', 'Stored ETags', 'Cached content types', 'Provider'];
+
+    const heights = await Promise.all(
+      labels.map(async (label) => {
+        const card = page
+          .getByText(label, { exact: true })
+          .first()
+          // The card Box is the nearest ancestor with a radius.
+          .locator('xpath=ancestor::*[contains(@class,"sc-")][3]')
+          .first();
+
+        const box = await card.boundingBox();
+        return box?.height ?? 0;
+      })
+    );
+
+    // Only the provider card carries a hint line, and before it was given a
+    // full-height box that made it taller than its three neighbours.
+    expect(new Set(heights).size).toBe(1);
+    expect(heights[0]).toBeGreaterThan(0);
+  });
+
+  test('reports the resolved routes for a cached content type', async ({ page, baseURL }) => {
+    await page.goto(DASHBOARD);
+
+    const row = rowFor(page, 'api::article.article');
+
+    await expect(row).toBeVisible();
+    await expect(row).toContainText('/api/articles');
+    // maxAge is milliseconds in config; showing the raw number is how a
+    // 1000x misconfiguration hides.
+    await expect(row).toContainText('1h');
+  });
+
+  test('purging updates the counts without a reload', async ({ page, baseURL }) => {
+    // Warm before loading the page: an earlier test may have purged, and this
+    // test is about the transition from a non-zero count to zero.
+    await warmCache(baseURL!);
+    await page.goto(DASHBOARD);
+
+    const row = rowFor(page, 'api::article.article');
+    // `td`, not getByRole('cell'): the design system's Td renders a gridcell
+    // role, so a cell lookup finds nothing.
+    const entries = row.locator('td').nth(1);
+
+    await expect(entries).not.toHaveText('0');
+
+    await row.getByRole('button', { name: 'Purge' }).click();
+    await page.getByRole('button', { name: 'Purge REST Cache' }).click();
+
+    // The point of this assertion: nothing reloads the page. The mutation
+    // invalidates the stats tag and the query re-runs on its own. Before, the
+    // figures stayed stale until the admin navigated away and back.
+    await expect(entries).toHaveText('0');
+  });
+
+  test('flags a content type that shares entries across callers', async ({ page, baseURL }) => {
+    await page.goto(DASHBOARD);
+
+    // api::category.category is configured with keys.useAuth, so its entries
+    // are keyed per caller and it should say so.
+    await expect(rowFor(page, 'api::category.category')).toContainText(
+      'Keyed per caller'
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -31,11 +31,14 @@
     "test:deps": "node scripts/check-undeclared-deps.cjs",
     "lint:workspaces": "pnpm -r run test:lint",
     "test:cluster": "node scripts/redis-cluster-check.cjs",
-    "test:esm": "node scripts/check-esm-bundle.cjs"
+    "test:esm": "node scripts/check-esm-bundle.cjs",
+    "test:admin": "playwright test -c e2e/playwright.config.ts",
+    "test:admin:ui": "playwright test -c e2e/playwright.config.ts --ui"
   },
   "license": "MIT",
   "devDependencies": {
     "0x": "^5.5.0",
+    "@playwright/test": "^1.62.1",
     "autocannon": "^7.7.1",
     "copyfiles": "^2.4.1",
     "cpy-cli": "^4.1.0",

--- a/packages/plugin-rest-cache/admin/src/components/ContentTypeTable/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/components/ContentTypeTable/index.tsx
@@ -20,7 +20,7 @@ import { useNotification } from '@strapi/strapi/admin';
 
 import { getTranslation } from '../../utils/getTranslation';
 import { formatDuration } from '../../utils/formatDuration';
-import { usePurgeCacheMutation } from '../../services/restCache';
+import { usePurgeCache } from '../../services/restCache';
 import type { ContentTypeStats } from '../../../../server/src/types/api';
 
 export interface ContentTypeTableProps {
@@ -32,14 +32,17 @@ export interface ContentTypeTableProps {
 const ContentTypeTable = ({ contentTypes, canPurge }: ContentTypeTableProps) => {
   const { formatMessage } = useIntl();
   const { toggleNotification } = useNotification();
-  const [purgeCache, { isLoading }] = usePurgeCacheMutation();
+  const purgeCache = usePurgeCache();
+  const [isLoading, setIsLoading] = useState(false);
   const [pendingUid, setPendingUid] = useState<string | null>(null);
 
   const handlePurge = async (uid: string) => {
+    setIsLoading(true);
+
     try {
       // Wildcard: the dashboard purges a whole content type, and its routes
       // carry params we cannot enumerate from here.
-      await purgeCache({ contentType: uid, params: {}, wildcard: true }).unwrap();
+      await purgeCache({ contentType: uid, params: {}, wildcard: true });
 
       toggleNotification({
         type: 'success',
@@ -57,6 +60,7 @@ const ContentTypeTable = ({ contentTypes, canPurge }: ContentTypeTableProps) => 
         }),
       });
     } finally {
+      setIsLoading(false);
       setPendingUid(null);
     }
   };

--- a/packages/plugin-rest-cache/admin/src/components/EditViewInfoDocumentPanel/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/components/EditViewInfoDocumentPanel/index.tsx
@@ -37,11 +37,9 @@ export interface EditViewInfoDocumentPanelDescription {
  * the max age is what answers that. The panel previously rendered an empty
  * body under a hardcoded English title, which answered neither.
  */
-const EditViewInfoDocumentPanel = ({
-  model,
-}: EditViewInfoDocumentPanelProps): EditViewInfoDocumentPanelDescription | null => {
+const EditViewInfoDocumentPanel = (props: EditViewInfoDocumentPanelProps): EditViewInfoDocumentPanelDescription | null => {
   const { formatMessage } = useIntl();
-  const { isEligible, config } = useCachedDocument(model);
+  const { isEligible, config } = useCachedDocument(props);
 
   if (!isEligible) {
     return null;

--- a/packages/plugin-rest-cache/admin/src/components/ListViewInjectedComponent/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/components/ListViewInjectedComponent/index.tsx
@@ -1,7 +1,5 @@
-import { useRBAC } from '@strapi/strapi/admin';
 import { useMatch } from 'react-router-dom';
 
-import pluginPermissions from '../../permissions';
 import PurgeCacheButton from '../PurgeCacheButton';
 
 /**
@@ -17,7 +15,6 @@ const LIST_VIEW_PATH = '/content-manager/:kind/:slug?';
  */
 const ListViewInjectedComponent = () => {
   const match = useMatch(LIST_VIEW_PATH);
-  const { allowedActions } = useRBAC(pluginPermissions);
 
   // Optional route segment, so the router types it as possibly absent. The
   // injection zone only exists inside this route, but nothing in the type
@@ -25,12 +22,6 @@ const ListViewInjectedComponent = () => {
   const slug = match?.params.slug;
 
   if (!slug) {
-    return null;
-  }
-
-  // Presentation only: the purge route carries an `admin::hasPermissions`
-  // policy for the same action.
-  if (!allowedActions.canReadStrategy || !allowedActions.canPurge) {
     return null;
   }
 

--- a/packages/plugin-rest-cache/admin/src/components/PurgeCacheButton/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/components/PurgeCacheButton/index.tsx
@@ -5,7 +5,7 @@ import { ArrowsCounterClockwise } from '@strapi/icons';
 import { useNotification } from '@strapi/strapi/admin';
 
 import { getTranslation } from '../../utils/getTranslation';
-import { useGetCacheStrategyQuery, usePurgeCacheMutation } from '../../services/restCache';
+import { useCacheStrategy, usePurgeCache } from '../../services/restCache';
 import type { PurgeRequest } from '../../../../server/src/types/api';
 
 export interface PurgeCacheButtonProps {
@@ -63,18 +63,21 @@ const PurgeCacheButton = ({
 
   // Shared with every other subscriber to the strategy on the page - RTK Query
   // collapses them onto one request, and unsubscribing cancels it.
-  const { data } = useGetCacheStrategyQuery();
-  const [purgeCache, { isLoading }] = usePurgeCacheMutation();
+  const { data } = useCacheStrategy();
+  const purgeCache = usePurgeCache();
+  const [isLoading, setIsLoading] = useState(false);
 
   const [showConfirmModal, setShowConfirmModal] = useState(false);
 
   const toggleConfirmModal = () => setShowConfirmModal((prevState) => !prevState);
 
   const handleConfirmDelete = async () => {
+    setIsLoading(true);
+
     try {
       // `unwrap` so a failed request rejects rather than resolving with an
       // `{ error }` object that would otherwise be reported as a success.
-      await purgeCache({ contentType, params, wildcard }).unwrap();
+      await purgeCache({ contentType, params, wildcard });
 
       toggleNotification({
         type: 'success',

--- a/packages/plugin-rest-cache/admin/src/components/PurgeDocumentAction/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/components/PurgeDocumentAction/index.tsx
@@ -5,7 +5,7 @@ import { ArrowsCounterClockwise } from '@strapi/icons';
 import { useNotification } from '@strapi/strapi/admin';
 
 import { getTranslation } from '../../utils/getTranslation';
-import { usePurgeCacheMutation } from '../../services/restCache';
+import { usePurgeCache } from '../../services/restCache';
 import { useCachedDocument } from '../../hooks/useCachedDocument';
 import type { EditViewContext } from '../../types/contentManager';
 
@@ -57,13 +57,11 @@ const getErrorMessage = (error: unknown): string | undefined => {
  * content-manager's document action contract. Returning null withdraws the
  * action, which is what useCachedDocument decides.
  */
-const PurgeDocumentAction = ({
-  model,
-}: PurgeDocumentActionProps): PurgeDocumentActionDescription | null => {
+const PurgeDocumentAction = (props: PurgeDocumentActionProps): PurgeDocumentActionDescription | null => {
   const { toggleNotification } = useNotification();
   const { formatMessage } = useIntl();
-  const [purgeCache] = usePurgeCacheMutation();
-  const { isEligible, params, isSingleType } = useCachedDocument(model);
+  const purgeCache = usePurgeCache();
+  const { isEligible, params, isSingleType } = useCachedDocument(props);
 
   if (!isEligible) {
     return null;
@@ -97,7 +95,7 @@ const PurgeDocumentAction = ({
         try {
           // A single type has one entry and no route parameters to narrow by,
           // so its purge is a wildcard over the whole content type.
-          await purgeCache({ contentType: model, params, wildcard: isSingleType }).unwrap();
+          await purgeCache({ contentType: props.model, params, wildcard: isSingleType });
 
           toggleNotification({
             type: 'success',

--- a/packages/plugin-rest-cache/admin/src/hooks/useCachedDocument.ts
+++ b/packages/plugin-rest-cache/admin/src/hooks/useCachedDocument.ts
@@ -1,27 +1,10 @@
-import {
-  useRBAC,
-  unstable_useContentManagerContext as useContentManagerContext,
-} from '@strapi/strapi/admin';
-
-import pluginPermissions from '../permissions';
-import { useGetCacheStrategyQuery } from '../services/restCache';
+import { useCacheStrategy } from '../services/restCache';
 import type { CacheContentTypeConfig } from '../../../server/src/types';
 import type { PurgeRequest } from '../../../server/src/types/api';
+import type { EditViewContext } from '../types/contentManager';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
-
-/**
- * `unstable_useContentManagerContext` types `form` as `unknown`, so its shape
- * has to be established at runtime rather than asserted.
- */
-const getInitialValues = (form: unknown): Record<string, unknown> => {
-  if (isRecord(form) && isRecord(form.initialValues)) {
-    return form.initialValues;
-  }
-
-  return {};
-};
 
 /**
  * Reduce a document's values to the ones that can appear in a cache key.
@@ -30,8 +13,12 @@ const getInitialValues = (form: unknown): Record<string, unknown> => {
  * anything; a relation or a component would stringify to `[object Object]` and
  * match nothing.
  */
-const toPurgeParams = (values: Record<string, unknown>): PurgeRequest['params'] => {
+const toPurgeParams = (values: unknown): PurgeRequest['params'] => {
   const params: Record<string, string | number> = {};
+
+  if (!isRecord(values)) {
+    return params;
+  }
 
   for (const [key, value] of Object.entries(values)) {
     if (typeof value === 'string' || typeof value === 'number') {
@@ -46,10 +33,9 @@ export interface CachedDocument {
   /**
    * Whether a purge control should be offered for the document currently open.
    *
-   * False for an entry that cannot have cached responses - one being created,
-   * or a draft that was never served over the REST API - for a content type
-   * that is not in the configured strategy, and for an admin without the
-   * permissions to see or act on any of it.
+   * False while an entry is being created - nothing has been written, so
+   * nothing can be cached - and for a content type that is not in the
+   * configured strategy.
    */
   isEligible: boolean;
   /** The strategy entry for this content type, when there is one. */
@@ -63,44 +49,37 @@ export interface CachedDocument {
 /**
  * Everything the two edit-view contributions need to decide whether to appear.
  *
- * Both the document action and the side panel ran the same four guards and the
- * same strategy lookup. Sharing it means they cannot disagree about whether a
- * document is cached - which would show a purge button beside a panel saying
- * the entry is not cached, or the reverse.
+ * Reads the context from the props the content-manager already passes rather
+ * than from `unstable_useContentManagerContext`. That hook is only valid
+ * inside the edit view, but Strapi evaluates registered document actions on
+ * the **list** view as well - and calling it there throws, which the error
+ * boundary turns into "Something went wrong" for the whole content-manager
+ * list. Every field needed here is on the props anyway.
+ *
+ * Nothing here reads the Auth context either: it is unreachable from a
+ * plugin's prebuilt chunk in a production admin build (see
+ * services/restCache), and the server enforces the same permissions on every
+ * route it exposes.
  */
-export const useCachedDocument = (model: string): CachedDocument => {
-  const { allowedActions } = useRBAC(pluginPermissions);
-  const { data } = useGetCacheStrategyQuery();
-  const { isCreatingEntry, form, isSingleType } = useContentManagerContext();
+export const useCachedDocument = ({
+  model,
+  document,
+  documentId,
+  collectionType,
+}: EditViewContext): CachedDocument => {
+  const { data } = useCacheStrategy();
 
-  const initialValues = getInitialValues(form);
   const config = data?.strategy?.contentTypes?.find(
     (contentType) => contentType.contentType === model
   );
 
-  // Both components previously also tested
-  // `hasDraftAndPublish && initialValues.publishedAt === null`, meaning "this
-  // is a draft, so nothing was ever served over REST". That condition could
-  // never be true: the edit form's values hold only the content type's own
-  // fields - documentId, title, description and so on - and `publishedAt` is
-  // not among them, so the comparison was always `undefined === null`.
-  //
-  // Removed rather than reimplemented against `document.status`, because
-  // hiding on drafts is not clearly right: a "modified" document has both a
-  // published version that is cached and unpublished edits, and that is
-  // exactly when someone needs to purge. Offering the control for a document
-  // with nothing cached costs a no-op request; withholding it when there is
-  // something cached leaves stale content served with no way to clear it.
-  const isEligible =
-    !isCreatingEntry &&
-    allowedActions.canReadStrategy === true &&
-    allowedActions.canPurge === true &&
-    config !== undefined;
+  const isSingleType = collectionType === 'single-types';
 
   return {
-    isEligible,
+    // Nothing has been written yet, so nothing can be cached.
+    isEligible: Boolean(documentId) && config !== undefined,
     config,
-    params: isSingleType ? {} : toPurgeParams(initialValues),
+    params: isSingleType ? {} : toPurgeParams(document),
     isSingleType,
   };
 };

--- a/packages/plugin-rest-cache/admin/src/index.ts
+++ b/packages/plugin-rest-cache/admin/src/index.ts
@@ -28,7 +28,7 @@ export default {
     //
     // The plugin had no settings entry at all before this: a HomePage existed
     // but nothing ever registered a route to it, so it was unreachable.
-    app.addSettingsLink(
+    app.createSettingSection(
       {
         id: pluginId,
         intlLabel: {
@@ -36,16 +36,18 @@ export default {
           defaultMessage: 'REST Cache',
         },
       },
-      {
-        id: `${pluginId}-overview`,
-        intlLabel: {
-          id: getTranslation('settings.page.label'),
-          defaultMessage: 'Overview',
+      [
+        {
+          id: `${pluginId}-overview`,
+          intlLabel: {
+            id: getTranslation('settings.page.label'),
+            defaultMessage: 'Overview',
+          },
+          to: pluginId,
+          Component: () => import('./pages/App'),
+          permissions: pluginPermissions.readStrategy,
         },
-        to: pluginId,
-        Component: () => import('./pages/App'),
-        permissions: pluginPermissions.readStrategy,
-      }
+      ]
     );
 
     app.widgets.register({

--- a/packages/plugin-rest-cache/admin/src/pages/App/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/pages/App/index.tsx
@@ -1,27 +1,28 @@
-import { Page } from '@strapi/strapi/admin';
-
 import SettingsPage from '../SettingsPage';
-import pluginPermissions from '../../permissions';
 
 /**
- * Route-level wrapper for the settings page.
+ * Route entry for the settings page.
  *
- * Page.Protect repeats the permission already given to the settings link.
- * That is deliberate rather than redundant: the link only controls what is
- * shown in the menu, and someone can navigate straight to the URL. Neither is
- * the real boundary - every admin route carries an `admin::hasPermissions`
- * policy for the same action - but a blank page beats a page that renders and
- * then fails every request behind it.
+ * Deliberately no `Page.Protect`, and nothing else here that reads the `Auth`
+ * context.
  *
- * This is one page, so there is no router here. The previous version declared
- * react-router v5 `Switch`/`component` routes against react-router v6, which
- * would have thrown had anything ever rendered it - nothing did, because no
- * menu link or settings section was ever registered.
+ * A plugin settings link is registered by pushing a lazy route into the
+ * `settings/*` children (see `createSettingsLink` in @strapi/admin's
+ * core/apis/router). From inside that lazily-loaded chunk, in a production
+ * admin build, the Auth context is not reachable: `useAuth` returns undefined
+ * and `useRBAC` throws "`useRBAC` must be used within `Auth`", which the error
+ * boundary turns into "Something went wrong". First-party settings pages are
+ * compiled into the host bundle and never hit this.
+ *
+ * It reproduces only under `strapi build` + `strapi start`, never under
+ * `strapi develop` - which is exactly why it survived manual testing and was
+ * caught by the browser suite instead.
+ *
+ * Permissions are therefore derived from the API - see SettingsPage. That is
+ * not a downgrade in safety: the UI gate never was the boundary. Every admin
+ * route carries an `admin::hasPermissions` policy for the same action, so the
+ * server refuses regardless of what the panel chooses to render.
  */
-const App = () => (
-  <Page.Protect permissions={pluginPermissions.readStrategy}>
-    <SettingsPage />
-  </Page.Protect>
-);
+const App = () => <SettingsPage />;
 
 export default App;

--- a/packages/plugin-rest-cache/admin/src/pages/SettingsPage/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/pages/SettingsPage/index.tsx
@@ -1,14 +1,21 @@
 import { useIntl } from 'react-intl';
 import { Box, Flex, Grid, Typography } from '@strapi/design-system';
 import { EmptyDocuments } from '@strapi/icons/symbols';
-import { Layouts, Page, useRBAC } from '@strapi/strapi/admin';
+import { Layouts, Page } from '@strapi/strapi/admin';
 
 import StatCard from '../../components/StatCard';
 import ContentTypeTable from '../../components/ContentTypeTable';
 import { getTranslation } from '../../utils/getTranslation';
 import { formatDuration } from '../../utils/formatDuration';
-import { useGetCacheStatsQuery } from '../../services/restCache';
-import pluginPermissions from '../../permissions';
+import { useCacheStats } from '../../services/restCache';
+
+/**
+ * useFetchClient rejects with an axios error, which carries the HTTP status on
+ * `response.status`. A 403 here means this admin holds no
+ * `cache.read-strategy` permission; the server is the authority on that.
+ */
+const isForbidden = (error: unknown): boolean =>
+  (error as { response?: { status?: number } })?.response?.status === 403;
 
 const SettingsPage = () => {
   const { formatMessage } = useIntl();
@@ -16,15 +23,19 @@ const SettingsPage = () => {
   // One request for the whole page. The stats endpoint already folds in the
   // provider name and the strategy flags, so there is no reason to also fetch
   // /config/strategy and /config/provider here.
-  const { data, isLoading, error } = useGetCacheStatsQuery();
+  const { data, isLoading, error } = useCacheStats();
 
-  const {
-    isLoading: isLoadingPermissions,
-    allowedActions: { canPurge },
-  } = useRBAC({ purge: pluginPermissions.purge });
-
-  if (isLoading || isLoadingPermissions) {
+  if (isLoading) {
     return <Page.Loading />;
+  }
+
+  // The server is the authority on permissions, and it has just answered. A
+  // 403 means this admin may not read the strategy; anything else is a real
+  // failure. Deriving it from the response rather than from `useRBAC` is not
+  // only simpler - the Auth context is not reachable from a lazily-loaded
+  // plugin settings route in a production build. See pages/App.
+  if (isForbidden(error)) {
+    return <Page.NoPermissions />;
   }
 
   if (error || !data) {
@@ -37,6 +48,12 @@ const SettingsPage = () => {
       />
     );
   }
+
+  // Purging is a separate action from reading, so an admin who can see this
+  // page cannot necessarily clear it. The button is rendered optimistically
+  // and the server refuses with a 403 it surfaces as a notification, which is
+  // the same contract the content-manager contributions use.
+  const canPurge = true;
 
   const { provider, strategy, totals, contentTypes } = data;
 

--- a/packages/plugin-rest-cache/admin/src/services/restCache.ts
+++ b/packages/plugin-rest-cache/admin/src/services/restCache.ts
@@ -1,15 +1,5 @@
-// These two imports bind nothing on purpose, and must not be removed.
-//
-// The hooks below have types that RTK Query infers, and declaration emit has
-// to write those types into a .d.ts. Under pnpm's isolated layout TypeScript
-// resolves @reduxjs/toolkit through a symlink into .pnpm/, cannot name the
-// package from there, and fails the build with TS2742. Referencing the package
-// by name here gives it a name to use. @reduxjs/toolkit is a devDependency for
-// the same reason: it is needed to compile, never imported at runtime - the
-// admin panel supplies the store, and `adminApi` below comes from Strapi.
-import type {} from '@reduxjs/toolkit';
-import type {} from '@reduxjs/toolkit/query/react';
-import { adminApi } from '@strapi/strapi/admin';
+import { useCallback, useEffect, useState } from 'react';
+import { useFetchClient } from '@strapi/strapi/admin';
 
 import { pluginId } from '../pluginId';
 import type {
@@ -22,60 +12,162 @@ import type {
 /**
  * Data access for the plugin's admin API.
  *
- * Built on the admin panel's own RTK Query instance rather than a bespoke
- * fetching layer, which buys three things the previous hook did not have:
+ * Built on `useFetchClient` rather than the admin panel's RTK Query instance,
+ * which looks like the more idiomatic choice and is not.
  *
- * - **Deduplication.** The strategy is needed by the purge button, the
- *   document action, the list-view injection and the edit-view panel. Each
- *   previously ran its own `useReducer` + fetch on mount, so opening a
- *   content-manager view issued the same request four times. RTK Query
- *   collapses concurrent subscribers onto one in-flight request.
- * - **Invalidation.** A purge now invalidates the stats tag, so the dashboard
- *   re-reads counts by itself instead of showing figures that are wrong the
- *   moment the button is pressed.
- * - **Cancellation.** Unsubscribing aborts in flight, replacing the
- *   hand-rolled AbortController that each component constructed on every
- *   render (and therefore never actually aborted the request it belonged to).
+ * A plugin ships as a prebuilt ES module that imports `@strapi/strapi/admin`
+ * as an external. Under `strapi develop` Vite dedupes that to the host's copy,
+ * so everything shared through it - the redux store, the RTK `adminApi`, the
+ * Auth context - is the same instance the panel uses. Under `strapi build` it
+ * does not: the plugin chunk gets its own copy of that module graph. Endpoints
+ * injected into "our" adminApi are then absent from the store's reducer, and
+ * the moment a response lands RTK dies with
+ *
+ *   TypeError: Cannot read properties of undefined (reading 'merge')
+ *
+ * leaving the page on its loading state forever. The same split makes the Auth
+ * context unreachable, which is why nothing here uses `useRBAC` either.
+ *
+ * `useFetchClient` is safe because it shares nothing but a function: it reads
+ * the token and returns an axios-like client, with no cross-module state.
+ *
+ * The deduplication and invalidation RTK gave us are kept, deliberately small,
+ * in the module-level cache below.
  */
-const api = adminApi
-  .enhanceEndpoints({
-    addTagTypes: ['RestCacheStrategy', 'RestCacheProvider', 'RestCacheStats'],
-  })
-  .injectEndpoints({
-    endpoints: (builder) => ({
-      getCacheStrategy: builder.query<StrategyResponse, void>({
-        query: () => `/${pluginId}/config/strategy`,
-        providesTags: ['RestCacheStrategy'],
-      }),
 
-      getCacheProvider: builder.query<ProviderResponse, void>({
-        query: () => `/${pluginId}/config/provider`,
-        providesTags: ['RestCacheProvider'],
-      }),
+type Listener = () => void;
 
-      getCacheStats: builder.query<CacheSummary, void>({
-        query: () => `/${pluginId}/stats`,
-        providesTags: ['RestCacheStats'],
-      }),
+interface Entry<T> {
+  data?: T;
+  error?: unknown;
+  promise?: Promise<void>;
+  /**
+   * Bumped on every invalidation.
+   *
+   * Subscribers depend on it, so clearing an entry re-runs their fetch effect.
+   * Without it, invalidating leaves `data` undefined and nothing ever asks for
+   * it again - the page sits on its loading state for good.
+   */
+  version: number;
+  listeners: Set<Listener>;
+}
 
-      purgeCache: builder.mutation<unknown, PurgeRequest>({
-        query: (body) => ({
-          url: `/${pluginId}/purge`,
-          method: 'POST',
-          data: body,
-        }),
-        // Counts change, configuration does not.
-        invalidatesTags: ['RestCacheStats'],
-      }),
-    }),
-    overrideExisting: false,
-  });
+/**
+ * One entry per endpoint.
+ *
+ * The strategy is read by the purge button, the document action, the list-view
+ * injection and the edit-view panel. Without this, opening a content-manager
+ * view issues the same request four times - which is exactly what the previous
+ * per-component `useReducer` + fetch did.
+ */
+const cache = new Map<string, Entry<unknown>>();
 
-export const {
-  useGetCacheStrategyQuery,
-  useGetCacheProviderQuery,
-  useGetCacheStatsQuery,
-  usePurgeCacheMutation,
-} = api;
+const entryFor = <T,>(key: string): Entry<T> => {
+  let entry = cache.get(key) as Entry<T> | undefined;
 
-export { api as restCacheApi };
+  if (!entry) {
+    entry = { version: 0, listeners: new Set() };
+    cache.set(key, entry as Entry<unknown>);
+  }
+
+  return entry;
+};
+
+const notify = (entry: Entry<unknown>) => {
+  entry.listeners.forEach((listener) => listener());
+};
+
+/** Drop cached responses so the next subscriber refetches. */
+export const invalidateCache = (keys: string[] = [...cache.keys()]) => {
+  for (const key of keys) {
+    const entry = cache.get(key);
+
+    if (entry) {
+      entry.data = undefined;
+      entry.error = undefined;
+      entry.promise = undefined;
+      entry.version += 1;
+      notify(entry);
+    }
+  }
+};
+
+export const STRATEGY_KEY = 'config/strategy';
+export const PROVIDER_KEY = 'config/provider';
+export const STATS_KEY = 'stats';
+
+interface QueryResult<T> {
+  data?: T;
+  error?: unknown;
+  isLoading: boolean;
+  refetch: () => void;
+}
+
+const useEndpoint = <T,>(key: string): QueryResult<T> => {
+  const { get } = useFetchClient();
+  const entry = entryFor<T>(key);
+  // Re-render on any change to the entry - a fetch completing as well as an
+  // invalidation. A counter derived from entry.version would not do: after a
+  // fetch resolves the version is unchanged, so setting it would be a no-op
+  // and the arriving data would never be painted.
+  const [, forceRender] = useState(0);
+
+  useEffect(() => {
+    const listener = () => forceRender((n) => n + 1);
+    entry.listeners.add(listener);
+
+    return () => {
+      entry.listeners.delete(listener);
+    };
+  }, [entry]);
+
+  useEffect(() => {
+    if (entry.data !== undefined || entry.error !== undefined || entry.promise) {
+      return;
+    }
+
+    // Concurrent subscribers await the same promise rather than each issuing
+    // their own request.
+    entry.promise = get(`/${pluginId}/${key}`)
+      .then((response) => {
+        entry.data = response.data as T;
+        entry.error = undefined;
+      })
+      .catch((error: unknown) => {
+        entry.error = error;
+      })
+      .finally(() => {
+        entry.promise = undefined;
+        notify(entry as Entry<unknown>);
+      });
+    // entry.version is read during render, so an invalidation - which bumps it
+    // and notifies - re-runs this effect and refetches.
+  }, [entry, get, key, entry.version]);
+
+  const refetch = useCallback(() => invalidateCache([key]), [key]);
+
+  return {
+    data: entry.data,
+    error: entry.error,
+    isLoading: entry.data === undefined && entry.error === undefined,
+    refetch,
+  };
+};
+
+export const useCacheStrategy = () => useEndpoint<StrategyResponse>(STRATEGY_KEY);
+export const useCacheProvider = () => useEndpoint<ProviderResponse>(PROVIDER_KEY);
+export const useCacheStats = () => useEndpoint<CacheSummary>(STATS_KEY);
+
+export const usePurgeCache = () => {
+  const { post } = useFetchClient();
+
+  return useCallback(
+    async (body: PurgeRequest) => {
+      await post(`/${pluginId}/purge`, body);
+
+      // Counts change, configuration does not.
+      invalidateCache([STATS_KEY]);
+    },
+    [post]
+  );
+};

--- a/packages/plugin-rest-cache/admin/src/widgets/CacheOverview/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/widgets/CacheOverview/index.tsx
@@ -3,7 +3,7 @@ import { Flex, Typography } from '@strapi/design-system';
 import { Widget } from '@strapi/strapi/admin';
 
 import { getTranslation } from '../../utils/getTranslation';
-import { useGetCacheStatsQuery } from '../../services/restCache';
+import { useCacheStats } from '../../services/restCache';
 
 /**
  * Homepage widget: how much is cached, and by what.
@@ -13,7 +13,7 @@ import { useGetCacheStatsQuery } from '../../services/restCache';
  */
 const CacheOverviewWidget = () => {
   const { formatMessage } = useIntl();
-  const { data, isLoading, error } = useGetCacheStatsQuery();
+  const { data, isLoading, error } = useCacheStats();
 
   if (isLoading) {
     return <Widget.Loading />;

--- a/playgrounds/memory/package.json
+++ b/playgrounds/memory/package.json
@@ -9,7 +9,8 @@
     "build": "strapi build",
     "strapi": "strapi",
     "test": "run-s test:*",
-    "test:e2e": "jest --forceExit"
+    "test:e2e": "jest --forceExit",
+    "e2e:serve": "strapi build && strapi start"
   },
   "dependencies": {
     "@strapi/plugin-users-permissions": "5.52.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       0x:
         specifier: ^5.5.0
         version: 5.8.0
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       autocannon:
         specifier: ^7.7.1
         version: 7.15.0
@@ -2199,6 +2202,11 @@ packages:
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17':
     resolution: {integrity: sha512-tXDyE1/jzFsHXjhRZQ3hMl0IVhYe5qula43LDWIhVfjp9G/nT5OQY5AORVOrkEGAUltBJOfOWeETbmhm6kHhuQ==}
@@ -6118,6 +6126,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -8701,6 +8714,16 @@ packages:
 
   player.style@0.0.8:
     resolution: {integrity: sha512-ScmFzio3634eEn+ejpkEw13F5xYvnPghtaZz/Kg7QQP78ECrxdjRVqwVPZhUwbYxmg5OIScByOgHfrHpzTtR1Q==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   plop@4.0.5:
     resolution: {integrity: sha512-pJz6oWC9LyBp5mBrRp8AUV2RNiuGW+t/HOs4zwN+b/3YxoObZOOFvjn1mJMpAeKi2pbXADMFOOVQVTVXEdDHDw==}
@@ -13010,6 +13033,10 @@ snapshots:
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.109.2(@swc/core@1.15.47(@swc/helpers@0.5.23))(esbuild@0.28.2)(postcss@8.5.26))':
     dependencies:
@@ -20080,6 +20107,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -23428,6 +23458,14 @@ snapshots:
   player.style@0.0.8:
     dependencies:
       media-chrome: 4.2.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plop@4.0.5(@types/node@22.20.1):
     dependencies:


### PR DESCRIPTION
The admin panel I shipped in #181 **does not work** under `strapi build` + `strapi start`.

It works perfectly under `strapi develop`, which is how I verified it. That difference is the whole story, and it is why this needed a browser suite rather than more careful manual checking.

## Root cause

A plugin ships as a prebuilt ES module importing `@strapi/strapi/admin` as an external. Under `develop`, Vite dedupes that to the host's copy — so the redux store, the RTK `adminApi` and the Auth context are all the same instances the panel uses. Under `build` they are not: **the plugin chunk gets its own copy of that module graph.**

Three failures followed, none visible to any test that existed:

| Symptom | Cause |
|---|---|
| Dashboard stuck on its loading spinner | Endpoints injected into "our" `adminApi` were absent from the store's reducer, so the first response killed RTK with `Cannot read properties of undefined (reading 'merge')` |
| *"You don't have the permissions to access that content"* — for a **super admin holding every permission** | `Page.Protect` read an Auth context that wasn't there |
| *"Something went wrong"* | `useRBAC` threw ``must be used within `Auth` `` |

Plus a fourth, independent one: both edit-view contributions called `unstable_useContentManagerContext`, which is only valid inside the edit view — but Strapi evaluates registered document actions **on the list view too**, where it throws and takes the entire content-manager list down with it.

## Fixes

- **Data layer moves to `useFetchClient`**, which shares nothing but a function and is safe across that boundary. This is why config-sync uses the fetch client rather than RTK — I understand that choice now.
- Deduplication and invalidation are kept in a small module-level cache, so the wins from #181 survive: the strategy is still fetched **once** for the four components that need it, and a purge still refreshes the counts **without a reload**.
- **Permissions are derived from the API** — a 403 from the stats endpoint is what "no access" means — instead of from a context. Not weaker: the UI gate never was the boundary. Every admin route carries an `admin::hasPermissions` policy for the same action, so the server refuses regardless of what the panel renders.
- The two edit-view contributions read context from the **props the content-manager already passes**, so they no longer depend on a hook that is invalid where Strapi calls them.

## The tests

`e2e/` boots the playground, builds its admin, and drives it in Chromium — 13 tests covering: the panel mounts, the settings link is registered, the dashboard shows live figures, all four stat cards are the same height (the alignment issue you spotted), purging updates counts without a reload, the homepage widget renders and links, and all three content-manager contributions appear — plus that an *uncached* content type gets none of them.

**I verified the suite fails when it should.** Reinstating the widget-icon bug from #181 makes the panel die so completely that global setup cannot even find the login form. A test that has never been seen red is not evidence of anything.

One test deserves a note: warming the cache has to use a **cookie-less** request context, because `page.request` carries the admin session cookie and the plugin's own default hitpass then declines to cache anything. The first version of that test passed for the wrong reason.

## CI

New `e2e_admin` job. One Node version only — it builds the admin panel, which costs minutes, and what it guards is browser behaviour rather than anything Node-version specific. Playwright traces and screenshots upload on failure.

## Verification

- 13/13 admin browser tests
- 116/116 server e2e
- `tsc --noEmit` clean for both admin and server, including declaration emit
- `check-esm-bundle` and `check-undeclared-deps` pass

## Worth reporting upstream

Two Strapi issues surfaced here that affect every community plugin, not just this one:

1. Plugin settings pages cannot use `useRBAC` or `Page.Protect` in a production build — the Auth context is unreachable from the plugin's chunk.
2. `WidgetArgs.icon` is typed optional but asserted with `invariant`, so omitting it takes down the entire admin panel with no console error.

Happy to file both if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)