### PR TITLE
chore: add CLAUDE.md and skills for maintainers and users

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "strapi-community-rest-cache",
+  "owner": {
+    "name": "Strapi Community",
+    "url": "https://github.com/strapi-community"
+  },
+  "plugins": [
+    {
+      "name": "rest-cache-helper",
+      "source": "./plugins/rest-cache-helper",
+      "description": "Configure and troubleshoot @strapi-community/plugin-rest-cache in a Strapi 5 project"
+    }
+  ]
+}

--- a/.claude/skills/add-a-provider/SKILL.md
+++ b/.claude/skills/add-a-provider/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: add-a-provider
+description: Add a new cache provider package to this repository, or modify an existing one. Use when working in packages/provider-rest-cache-*, implementing a storage backend, or changing the CacheProvider contract.
+---
+
+# Adding a cache provider
+
+A provider is a small package that stores and retrieves cache entries. The
+contract is `packages/plugin-rest-cache/server/src/types/CacheProvider.ts` —
+read it first; its comments cite the bugs each decision prevents.
+
+## The contract
+
+Required: `get(key)`, `set(key, value, maxAge)`, `del(key)`, `keys()`, and a
+`ready` getter.
+
+Optional: `delMany(keys)` and `clear()`. The base class supplies working
+defaults, so a provider written against the older contract keeps working.
+Override them when the backing store has batch operations — a purge is
+otherwise one round trip per key, which on Redis meant roughly 20,000 round
+trips and 55MB transferred for a 100k-entry cache.
+
+## Rules that are not stylistic
+
+**`maxAge` is milliseconds. Do not convert it.** cache-manager's ttl is also
+milliseconds. Converting again is how a configured hour became 41.7 days.
+
+**`keys()` must return unqualified keys**, without the store's prefix and
+without any adapter-internal qualification. `@keyv/redis` tracks keys as
+`keyv:/api/foo`; returning that form makes purge patterns match nothing while
+the deletes address keys that do not exist.
+
+**Keep the package CommonJS.** Providers are loaded via
+`createRequire(...)(modulePath)`. If a dependency is ESM-only — `quick-lru` v7
+is — resolve it through an async static `create()` rather than making the
+package ESM. See `MemoryCacheProvider.create()`.
+
+**Do not rename the provider class.** `bootstrap.ts` identifies a provider by
+walking the constructor chain comparing `constructor.name`, because a provider
+resolves its own copy of the types bundle and a real `instanceof` is false.
+A rename breaks provider loading with a misleading "does not export a
+CacheProvider instance" error.
+
+**Handle interop defensively.** `keyv` v4 exports its constructor directly,
+v5 exports it as `.default`, and `@keyv/redis` exposes only `.default` from its
+CJS build. Which one you get depends on what won the hoist in the host
+application, so accept either:
+
+```ts
+const keyvModule = require('keyv');
+const Keyv = keyvModule.default ?? keyvModule;
+```
+
+## Package shape
+
+The entry point must export:
+
+```ts
+module.exports = {
+  provider: 'myprovider',
+  name: 'My Provider',
+  async init(options, { strapi }) {
+    return MyCacheProvider.create(options);
+  },
+};
+```
+
+The plugin resolves `@strapi-community/provider-rest-cache-<name>` from the
+provider `name` in configuration. Arbitrary npm packages are not yet supported
+(there is a `@TODO` in `bootstrap.ts`).
+
+## Cluster safety
+
+If the backing store is distributed, a multi-key delete may span shards. Redis
+Cluster rejects it outright:
+
+```
+CROSSSLOT Keys in request don't hash to the same slot
+```
+
+The redis provider deletes key by key when `store.redis.isCluster`, and batches
+only the tracking-set update, which is a single key. Do the equivalent.
+
+## Verifying
+
+```bash
+pnpm --filter @strapi-community/provider-rest-cache-<name> run build
+pnpm run test:smoke     # loads the built provider and exercises it
+pnpm run test:deps      # every import must be declared
+pnpm run test:e2e:redis # if your provider is redis-shaped
+pnpm run test:cluster   # cluster-safety check, needs the built dist
+```
+
+Then run the full memory suite too — the plugin's behaviour is provider-agnostic
+and regressions show up there.
+
+## Documenting it
+
+A new provider needs a page under `docs/guide/providers/`, an entry in the
+sidebar (`docs/.vitepress/config.js`), and a row in
+`docs/guide/providers/index.md`. Follow the existing pages: every config sample
+carries both JavaScript and TypeScript tabs.

--- a/.claude/skills/verify-a-change/SKILL.md
+++ b/.claude/skills/verify-a-change/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: verify-a-change
+description: Verify a change to this plugin before opening a PR. Use after modifying anything under packages/, especially admin code, providers, or cache behaviour, and before claiming that something works.
+---
+
+# Verifying a change
+
+A typecheck is not verification. A passing build is not verification. This
+repository has shipped code that compiled, built, passed every test, and was
+completely broken in production.
+
+## Always
+
+```bash
+pnpm run build:plugin:rest-cache   # playgrounds resolve the built dist, not src
+pnpm run test:lint                 # typechecks server AND admin
+pnpm run test:e2e:memory           # 116 specs, boots Strapi in-process
+```
+
+`build:plugin:rest-cache` first, every time. The playgrounds consume `dist/`,
+so an unbuilt change is invisible to every test below it and you will debug a
+stale artifact.
+
+## If you touched `admin/`
+
+```bash
+pnpm run test:admin
+```
+
+Non-negotiable. The admin panel behaves **differently** under `strapi develop`
+than under `strapi build`: in dev, Vite dedupes `@strapi/strapi/admin` to the
+host's copy; in a production build the plugin chunk gets its own copy of that
+module graph. A change verified only in `strapi develop` has not been verified.
+
+Symptoms this catches, all of which have happened here: the dashboard hanging
+on its loading state, `Page.Protect` refusing a super admin, `useRBAC` throwing
+`must be used within Auth`, and the content-manager list view dying outright.
+
+First run needs `pnpm exec playwright install chromium`.
+
+## If you touched a provider or package shape
+
+```bash
+pnpm run test:deps    # every import must be a declared dependency
+pnpm run test:esm     # the .mjs bundle must contain no CommonJS-only globals
+pnpm run test:smoke   # loads the built providers and exercises them
+```
+
+`test:esm` exists because `require.resolve` once survived into the ESM bundle,
+where `require` does not exist, and the plugin failed to boot for anyone whose
+runtime took the `import` branch of the exports map. The e2e suite could not
+see it — it loads the CommonJS entry.
+
+## If you touched caching or invalidation behaviour
+
+Run the redis suite too. It exercises code paths the memory provider does not
+have — cluster-safe deletes, the key-tracking set, prefix handling:
+
+```bash
+pnpm run test:e2e:redis    # needs a local redis on 6379
+```
+
+## Prove the test can fail
+
+If you added a test for a specific bug, break the fix on purpose and confirm
+the test goes red, then restore it. A test that has never been seen red is not
+evidence that it checks anything.
+
+Two real examples from this repo:
+
+- a coalescing test passed before the feature existed, because in-memory
+  responses were too fast to overlap — it needed artificial origin latency to
+  become a real test;
+- a cache-warming step in a browser test silently cached nothing, because it
+  used a client that sent the admin session cookie and the default `hitpass`
+  declined to cache it.
+
+## Before claiming it works
+
+State what you actually ran. If you verified an admin change in
+`strapi develop` only, say that, and say it is not sufficient.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repository.
+
+`CONTRIBUTING.md` is the human-facing version and is more complete on setup.
+This file is the short version plus the things that have actually cost people
+time here.
+
+## What this is
+
+`@strapi-community/plugin-rest-cache` — a Strapi 5 plugin that caches REST API
+responses and invalidates them when content changes. A pnpm workspace monorepo.
+
+| Path | What it is |
+| --- | --- |
+| `packages/plugin-rest-cache` | The plugin. `server/` and `admin/`, both TypeScript. |
+| `packages/provider-rest-cache-*` | Cache backends (memory, redis). Published separately. |
+| `playgrounds/{memory,redis}` | Real Strapi apps used as test hosts. |
+| `shared/tests` | Jest e2e specs, **copied into both playgrounds** by `postinstall`. |
+| `e2e/` | Playwright browser tests for the admin panel. |
+| `docs/` | VitePress site. `docs:build` regenerates the TypeDoc API reference first. |
+| `scripts/` | Custom CI checks — read these before adding a new one. |
+
+Edit specs in `shared/tests/`, never in `playgrounds/*/tests/` — those are
+copies and will be overwritten.
+
+## Things that will bite you
+
+**Every duration is milliseconds.** `maxAge`, `ttl`, everywhere. A past bug
+converted them twice, so a configured hour lived 41.7 days. Never add a
+conversion. `server/src/types/common.ts` brands the type to make the mistake a
+compile error; read that file — its comments are the house style for explaining
+*why*.
+
+**The admin panel behaves differently under `strapi develop` and
+`strapi build`.** In dev, Vite dedupes `@strapi/strapi/admin` to the host's
+copy. In a production build, the plugin chunk gets its own copy of that module
+graph. Consequences, all of which shipped once:
+
+- do **not** use the admin's RTK `adminApi` from plugin code — endpoints
+  injected into "our" copy are absent from the store's reducer, and the first
+  response kills it with `Cannot read properties of undefined (reading 'merge')`;
+- do **not** use `useRBAC` or `Page.Protect` — the Auth context is unreachable
+  and `useRBAC` throws;
+- use `useFetchClient`, and derive permissions from API responses (a 403 is the
+  answer). The server enforces permissions on every route regardless.
+
+Verifying an admin change in `strapi develop` proves nothing. Run
+`pnpm run test:admin`.
+
+**Content-manager contributions are evaluated on the list view too.** Document
+actions and side panels must not call `unstable_useContentManagerContext` —
+it throws outside the edit view and takes the whole list down. Use the props
+the content-manager passes.
+
+**Providers must stay CommonJS.** They are loaded with
+`createRequire(...)(modulePath)`. `quick-lru` v7 and `chalk` v5 are ESM-only,
+which is why the memory provider resolves its dependency through an async
+`create()`. Do not "modernise" this.
+
+**Provider classes are identified by name.** `bootstrap.ts` walks the
+constructor chain comparing `constructor.name`, because a provider package
+resolves its own copy of the types bundle so a real `instanceof` is false.
+Renaming `MemoryCacheProvider` or `RedisCacheProvider` breaks provider loading.
+
+**The default `hitpass` bypasses anything with an `authorization` or `cookie`
+header.** In tests this means a request made with an authenticated context
+caches nothing. Warm the cache from a cookie-less client — `e2e/helpers.ts`
+does this deliberately.
+
+## Verifying
+
+A typecheck is not verification. Neither is a passing build.
+
+```bash
+pnpm run build:plugin:rest-cache   # required before the playgrounds see changes
+pnpm run test:e2e:memory           # jest, boots Strapi in-process
+pnpm run test:e2e:redis            # needs a local redis
+pnpm run test:admin                # playwright, builds the admin and drives it
+pnpm run test:lint                 # typechecks server AND admin
+pnpm run test:deps                 # imports must be declared dependencies
+pnpm run test:esm                  # the .mjs bundle must have no CJS globals
+```
+
+`test:admin` needs `pnpm exec playwright install chromium` once.
+
+When a test is meant to catch a specific failure, **make it fail on purpose
+once**. A test that has never been seen red is not evidence. Several bugs here
+were found only because a supposedly-passing test was checked that way — and
+one test passed for the wrong reason until it was.
+
+## Conventions
+
+- TypeScript on both halves. Named exports; keep export shapes stable, Strapi
+  reads several of them by convention.
+- Comments explain **why**, not what — ideally citing the issue whose bug the
+  code prevents. Do not delete such comments while refactoring.
+- Conventional commits. Commit messages describe the reasoning, not a diff
+  summary.
+- Never convert a duration. Never widen a permission to make a test pass.
+
+## Release
+
+Publishing is **manual, always**. There is no automated release on merge, by
+deliberate policy. See `.claude/skills/` for the release procedure.

--- a/plugins/rest-cache-helper/.claude-plugin/plugin.json
+++ b/plugins/rest-cache-helper/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "rest-cache-helper",
+  "description": "Configure and troubleshoot @strapi-community/plugin-rest-cache in a Strapi 5 project",
+  "version": "1.0.0",
+  "author": {
+    "name": "Strapi Community",
+    "url": "https://github.com/strapi-community"
+  },
+  "homepage": "https://strapi-community.github.io/plugin-rest-cache/",
+  "repository": "https://github.com/strapi-community/plugin-rest-cache",
+  "license": "MIT",
+  "keywords": ["strapi", "cache", "rest", "redis", "performance"]
+}

--- a/plugins/rest-cache-helper/skills/configure-rest-cache/SKILL.md
+++ b/plugins/rest-cache-helper/skills/configure-rest-cache/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: configure-rest-cache
+description: Choose and write a Strapi REST Cache configuration for a specific use case. Use when setting up @strapi-community/plugin-rest-cache, deciding what to cache and for how long, picking between the memory and redis providers, caching authenticated or per-locale responses, or tuning cache keys.
+---
+
+# Configuring REST Cache
+
+Do not write a configuration before establishing the four things below. Most
+bad cache configurations are bad because one of them was assumed.
+
+## Establish first
+
+1. **How many Strapi instances run in production?** More than one means the
+   memory provider is wrong — each process would hold its own cache and a purge
+   would only reach one of them. That decision is not tunable later without
+   changing infrastructure.
+2. **Is the traffic public, authenticated, or both?** Authenticated caching is
+   safe only with per-caller keys, and is off by default for that reason.
+3. **Which routes actually hurt?** Caching everything is rarely the goal.
+   A few expensive endpoints often account for most of the load.
+4. **How stale may content be?** Usually the answer is "it may not be" — which
+   is fine, because invalidation is automatic. `maxAge` is a backstop for
+   changes nothing observed, not the primary mechanism.
+
+Ask the user these if the answers are not already evident from their project.
+
+## Then pick a starting point
+
+Each of these is a complete, copy-pasteable configuration with the trade-offs
+written out. Prefer sending the user to the matching one over inventing a
+config from scratch.
+
+| Situation | Recipe |
+| --- | --- |
+| Public, read-heavy content API | [public-content](https://strapi-community.github.io/plugin-rest-cache/guide/recipes/public-content.html) |
+| Per-user or token-authenticated responses | [authenticated](https://strapi-community.github.io/plugin-rest-cache/guide/recipes/authenticated.html) |
+| Several instances behind a load balancer | [multi-instance](https://strapi-community.github.io/plugin-rest-cache/guide/recipes/multi-instance.html) |
+| Only a few slow endpoints | [expensive-routes](https://strapi-community.github.io/plugin-rest-cache/guide/recipes/expensive-routes.html) |
+| i18n, or heavy filter/pagination/populate use | [i18n-and-query](https://strapi-community.github.io/plugin-rest-cache/guide/recipes/i18n-and-query.html) |
+| Preview or draft workflows | [previews-drafts](https://strapi-community.github.io/plugin-rest-cache/guide/recipes/previews-drafts.html) |
+
+Full option reference:
+https://strapi-community.github.io/plugin-rest-cache/guide/reference/config.html
+
+## Rules that are not negotiable
+
+**Durations are milliseconds.** `maxAge: 3600` is 3.6 seconds. One hour is
+`3600000`. Write the value with a comment saying what it is in human units.
+
+**Never set `hitpass: false` without `keys.useAuth: true`.** Together they
+cache authenticated traffic keyed per caller. `hitpass: false` alone means two
+callers authorised for the same route share one entry, and whoever misses first
+decides what everybody else sees. The server logs a warning at boot if you do
+this, and the admin panel flags the content type — but by then it is already
+serving.
+
+**Custom route paths must include the API prefix**, exactly as Strapi
+registered them: `/api/articles/slug/:slug`.
+
+**Match `keysPrefix` to your Redis `keyPrefix`** if the connection sets one.
+A mismatch means the plugin enumerates nothing, and every purge silently does
+nothing.
+
+## Sanity-check the result
+
+Have the user turn on `enableXCacheHeaders`, then:
+
+```bash
+curl -sI http://localhost:1337/api/articles | grep -i x-cache   # MISS
+curl -sI http://localhost:1337/api/articles | grep -i x-cache   # HIT
+```
+
+Then edit that content in the admin panel and request again — it should be
+`MISS`, proving invalidation works.
+
+`HITPASS` means the request bypassed the cache; with the default `hitpass` a
+browser session will always do that. Test with `curl`.
+
+If any of that does not behave, switch to the `diagnose-rest-cache` skill.
+
+## Writing the config
+
+Both `./config/plugins.js` and `./config/plugins.ts` are supported. Match
+whichever the project already uses, and keep the plugin's block under the
+`rest-cache` key with everything inside `config`.

--- a/plugins/rest-cache-helper/skills/diagnose-rest-cache/SKILL.md
+++ b/plugins/rest-cache-helper/skills/diagnose-rest-cache/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: diagnose-rest-cache
+description: Diagnose why Strapi REST Cache is not caching, is serving stale content, or is caching the wrong thing. Use when responses are not being cached, X-Cache shows MISS or HITPASS unexpectedly, content stays stale after an edit, or one user sees another user's data.
+---
+
+# Diagnosing REST Cache
+
+Work through this in order. Do not guess at configuration changes before
+establishing which of the failure modes is happening — they look identical from
+the outside and have completely different causes.
+
+## Step 1: get the `X-Cache` header
+
+This single header identifies the problem in most cases. It is off by default.
+
+```js
+// ./config/plugins.js
+strategy: {
+  enableXCacheHeaders: true,
+}
+```
+
+Restart Strapi, then request the failing route **twice** with `curl` — not a
+browser:
+
+```bash
+curl -sI http://localhost:1337/api/articles | grep -i x-cache
+curl -sI http://localhost:1337/api/articles | grep -i x-cache
+```
+
+Then branch on what you see.
+
+## `X-Cache: HITPASS`
+
+The request deliberately bypassed the cache. This is the most common false
+alarm.
+
+The shipped `hitpass` skips any request carrying an `authorization` or `cookie`
+header. **A browser logged into the admin panel sends a cookie on every
+request**, so testing in a browser tab will always show HITPASS.
+
+- Testing from a browser? Retest with `curl`, or a private window with no
+  session.
+- Genuinely need authenticated traffic cached? That requires turning `hitpass`
+  off **and** turning on per-caller keys. Doing the first without the second
+  makes two callers share one entry. Read
+  https://strapi-community.github.io/plugin-rest-cache/guide/recipes/authenticated.html
+
+## `X-Cache: MISS` every time
+
+The response is being refused. The plugin will not store a response that:
+
+- is empty, or has a non-`2xx` status;
+- is a stream (it can only be consumed once);
+- sets a `Set-Cookie` header — replaying that would hand one caller's session
+  to everybody;
+- says `Cache-Control: no-store` or `private`.
+
+Check the response headers of the failing request for `Set-Cookie` and
+`Cache-Control`. A custom middleware or controller setting either of these is
+the usual cause.
+
+## No `X-Cache` header at all
+
+The route is not cached — the middleware was never attached to it. This is
+configuration, not runtime.
+
+1. Is the content type listed in `strategy.contentTypes`? Nothing is cached
+   until it is named.
+2. Is it a **custom route**? Those must be listed explicitly, and `path` must
+   be the path **as Strapi registered it, including the API prefix** —
+   `/api/articles/slug/:slug`, not `/articles/slug/:slug`.
+3. Turn on `strategy.debug: true` (or run with
+   `DEBUG=strapi:plugin-rest-cache`). Routes that could not be matched are
+   logged:
+
+   ```
+   [WARNING] route "[GET] /articles/slug/:slug" not registered in strapi, ignoring...
+   ```
+
+4. If the admin panel is available, open **Settings → REST Cache**. The routes
+   listed per content type are the ones actually resolved. A route missing
+   there did not match.
+
+## Stale content after an edit
+
+Invalidation runs from Strapi's document service, which covers REST, GraphQL,
+the content manager, Content Releases and any `strapi.documents()` call.
+
+- Was the content changed **directly in the database**? Nothing can observe
+  that. Purge manually.
+- Otherwise check `enableDocumentServiceMiddleware` is on (it is by default).
+  With it off, the plugin only sees writes arriving on routes it knows about.
+
+## Entries expire far too late, or immediately
+
+`maxAge` is **milliseconds**. `3600` is 3.6 seconds; `3600000` is one hour.
+This is the single most common configuration mistake.
+
+## One caller sees another caller's data
+
+Stop and treat this as urgent.
+
+It means responses that vary per caller are being cached under a key that does
+not identify the caller. Either `hitpass` was disabled without setting
+`keys.useAuth: true`, or a route returns per-user data while being treated as
+public.
+
+Immediate mitigation: re-enable `hitpass` for that content type, and purge.
+Then read the authenticated-caching recipe before re-enabling.
+
+## Multiple instances behaving inconsistently
+
+The `memory` provider is per-process. Two Strapi instances have two independent
+caches, and a purge on one does not reach the other — so one instance serves
+fresh content and another serves stale. Use the Redis provider.
+https://strapi-community.github.io/plugin-rest-cache/guide/recipes/multi-instance.html
+
+## Still stuck
+
+Collect: plugin/Strapi/Node versions, the provider, the `rest-cache` config
+block, the `X-Cache` value, and the `DEBUG=strapi:plugin-rest-cache` output.
+Open an issue with the bug report form:
+https://github.com/strapi-community/plugin-rest-cache/issues/new/choose


### PR DESCRIPTION
Two audiences, two mechanisms — they need different content and are reached differently.

## Maintainers — `.claude/skills/`, repo-local

`verify-a-change` and `add-a-provider`, both written around failures this repo has **actually had** rather than the happy path:

- A typecheck and a green build are not verification. An admin change verified under `strapi develop` has not been verified at all, because the module graph differs in a production build — that's #184.
- A test that has never been seen red is not evidence. Includes the two real cases from this repo where a test passed for the wrong reason (the coalescing test that passed before the feature existed; the cache-warming step that cached nothing because it sent a session cookie).
- `maxAge` is milliseconds; provider classes are identified by `constructor.name`; providers must stay CommonJS.

`CLAUDE.md` carries the same short list, since it loads every session whereas a skill is only read when relevant.

## Users — a Claude Code plugin, via a marketplace

`configure-rest-cache` and `diagnose-rest-cache`, for people using the published plugin in their own Strapi project.

These **can't** live in `.claude/skills/` — that's only read inside this repo. They also can't ship inside the npm package, because Claude Code does not scan `node_modules` (I checked; that was my first assumption and it's wrong). The supported route is a plugin listed in a marketplace, so the repo now carries `.claude-plugin/marketplace.json` plus a plugin under `plugins/rest-cache-helper`:

```
/plugin marketplace add strapi-community/plugin-rest-cache
/plugin install rest-cache-helper@strapi-community-rest-cache
```

`diagnose-rest-cache` is structured like the troubleshooting page — get `X-Cache` first, then branch — because `HIT`/`MISS`/`HITPASS` have completely different causes and guessing between them is where the time goes. `configure-rest-cache` refuses to write a config before establishing instance count, auth shape, which routes actually hurt, and the staleness budget, then hands off to the matching recipe.

## Worth a look

- **The marketplace install commands are untested.** I can't install a marketplace from an unmerged branch to verify, so the exact `/plugin install` name-resolution (`rest-cache-helper@strapi-community-rest-cache`) is from the docs, not from a run. Worth trying once this is on `main`, and I'll correct the README if it differs.
- A `cut-a-release` skill is deliberately absent — it lands with the release workflows, so it can describe what actually exists.
- If you'd rather user-facing skills lived in a separate repo than the plugin source, say so; moving them later is cheap, but the install path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)