### PR TITLE
ci: add manually-triggered release automation

### DIFF
--- a/.claude/skills/cut-a-release/SKILL.md
+++ b/.claude/skills/cut-a-release/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: cut-a-release
+description: Publish this plugin to npm - a production release, a pre-release, or an experimental build from a branch. Use when preparing or shipping a release, updating the changelog, or debugging the publish workflow.
+---
+
+# Cutting a release
+
+Publishing is **always manual**. There is no trigger that publishes on merge,
+and there must never be one. Two humans gates stand in front of npm: pressing
+"Publish release" on a draft, and approving the deployment environment.
+
+## The pieces
+
+| | |
+| --- | --- |
+| `release-please.yml` | Watches `main`, maintains one rolling release PR, and creates **draft** GitHub Releases. Publishes nothing. |
+| `publish.yml` | The only thing that talks to npm. Never fires on merge. |
+| `release-please-config.json` | Changelog sections, package list, `draft: true`. |
+| `.release-please-manifest.json` | Current version per package. release-please owns this; do not hand-edit. |
+
+## Production release
+
+1. Merge work to `main` using conventional commits. release-please keeps a
+   `chore: release X.Y.Z` PR up to date, with the changelog grouped by change
+   type.
+2. Review that PR. The version comes from the commit types since the last
+   release — `feat` gives a minor, `fix` a patch, `!` or a `BREAKING CHANGE:`
+   footer a major. If the proposed version is wrong, the commit messages are
+   wrong; fix them rather than editing the version.
+3. Merge it. release-please tags and creates **draft** Releases.
+4. Go to Releases, review, press **Publish release**.
+5. `publish.yml` starts and waits on the `npm-latest` environment. A maintainer
+   approves. It packs and publishes to the `latest` tag.
+
+The draft step is not ceremony: a Release created by `GITHUB_TOKEN` does not
+trigger other workflows, so an auto-published one would silently never reach
+npm.
+
+## Pre-release
+
+Same flow, but mark the GitHub Release as a pre-release before publishing it.
+`publish.yml` reads `github.event.release.prerelease` and switches to the
+`next` dist-tag and the `npm-prerelease` environment.
+
+Users install with `npm install @strapi-community/plugin-rest-cache@next`.
+
+## Experimental build from a branch
+
+For trying a change in a real application before merging it.
+
+Run the **publish** workflow from the **Actions** tab:
+
+- keep the branch selector on **main** — this matters, see below;
+- `mode`: `experimental`;
+- `target_branch`: the branch to build.
+
+It publishes `0.0.0-experimental.<sha>` to the `experimental` dist-tag. Install
+by exact version, not by tag — the tag is clobbered by the next experimental
+build:
+
+```bash
+npm install @strapi-community/plugin-rest-cache@0.0.0-experimental.<sha>
+```
+
+### Why the branch selector must stay on main
+
+npm trusted publishing is **not branch-scoped**. It checks the repository, the
+workflow *filename* and the environment, and discards the ref. Since
+`workflow_dispatch` runs the workflow file from the branch you pick, choosing a
+feature branch would hand that branch's own YAML a publish-capable token — and
+`npm publish` defaults to `--tag latest`.
+
+So the workflow takes the branch as an *input* instead. The build job checks it
+out but has no `id-token` and no environment; the publish job runs from main's
+YAML and asserts the version matches `0.0.0-experimental.<40 hex>` before
+publishing. Both halves are needed: without the assertion, a poisoned build
+could stamp `5.99.0`, which every `^5.0.0` range would resolve regardless of
+dist-tag.
+
+## Things that will break a release
+
+**Never `npm publish` from a package directory.** npm does not understand the
+`workspace:` protocol and would publish `workspace:*` literally, producing a
+manifest nobody can install. The workflow runs `pnpm pack` first and publishes
+the tarball. The plugin depends on the memory provider this way, so this
+affects the primary package.
+
+**The build must run before packing, and in order.** The providers typecheck
+against the plugin's emitted declarations, so `pnpm run build` builds the
+plugin first, then the providers. `files` is `["dist"]` — an unbuilt package
+publishes an empty directory.
+
+**Node 24 or newer in the publish job.** Trusted publishing needs npm ≥ 11.5.1
+and no Node 22 release ships one.
+
+## If a publish fails
+
+- *Waiting for approval* — expected. Someone with reviewer rights approves the
+  deployment.
+- *401/403 from npm* — the trusted publisher config on npmjs.com does not match
+  this workflow's filename or environment name. Both are exact, case-sensitive
+  strings.
+- *`ERESOLVE` installing an experimental build* — the internal peer ranges were
+  not rewritten. `scripts/stamp-experimental-version.mjs` pins them to the exact
+  experimental version because a `^5.x` peer cannot satisfy `0.0.0-*`.
+- *Version assertion failed* — the build produced a version that does not match
+  the mode. Treat this as a real signal, not a check to relax.
+
+## Never
+
+- Add a publish trigger on push, merge, or PR.
+- Give the build job `id-token: write`.
+- Remove the version-shape assertion.

--- a/.claude/skills/cut-a-release/SKILL.md
+++ b/.claude/skills/cut-a-release/SKILL.md
@@ -44,9 +44,18 @@ Same flow, but mark the GitHub Release as a pre-release before publishing it.
 
 Users install with `npm install @strapi-community/plugin-rest-cache@next`.
 
+## Experimental build from a pull request
+
+The easy path. Add the **`publish-experimental`** label to a pull request. It
+publishes `0.0.0-experimental.<pr head sha>` to the `experimental` dist-tag,
+republishes on every subsequent push to that PR, and keeps a comment on the PR
+with the exact install command.
+
+Same-repo pull requests only; a fork PR never reaches the publish job.
+
 ## Experimental build from a branch
 
-For trying a change in a real application before merging it.
+When there is no pull request, or you want a specific branch.
 
 Run the **publish** workflow from the **Actions** tab:
 
@@ -62,13 +71,25 @@ build:
 npm install @strapi-community/plugin-rest-cache@0.0.0-experimental.<sha>
 ```
 
-### Why the branch selector must stay on main
+### Why the branch selector must stay on main, and why the PR trigger is `pull_request_target`
 
 npm trusted publishing is **not branch-scoped**. It checks the repository, the
 workflow *filename* and the environment, and discards the ref. Since
 `workflow_dispatch` runs the workflow file from the branch you pick, choosing a
 feature branch would hand that branch's own YAML a publish-capable token — and
 `npm publish` defaults to `--tag latest`.
+
+The label trigger has the same problem in a different shape: plain
+`pull_request` would run the PR branch's copy of the workflow, with publish
+credentials in scope. That is what Strapi's own experimental workflow does, and
+it is a real accepted risk on their side. This one uses
+`pull_request_target`, which runs the workflow file as it exists on the default
+branch, so neither the environment gate nor the version assertion can be edited
+by the branch being published.
+
+The usual `pull_request_target` trap - checking out untrusted code in a job
+holding secrets - does not apply here, because the build job holds neither
+secrets nor an id-token.
 
 So the workflow takes the branch as an *input* instead. The build job checks it
 out but has no `id-token` and no environment; the publish job runs from main's
@@ -78,6 +99,10 @@ could stamp `5.99.0`, which every `^5.0.0` range would resolve regardless of
 dist-tag.
 
 ## Things that will break a release
+
+**Everything publishing lives in `publish.yml` and must stay there.** npm
+validates the workflow *filename* and allows only one trusted-publisher config
+per package, so a second publishing workflow file would fail authentication.
 
 **Never `npm publish` from a package directory.** npm does not understand the
 `workspace:` protocol and would publish `workspace:*` literally, producing a
@@ -108,6 +133,10 @@ and no Node 22 release ships one.
 
 ## Never
 
-- Add a publish trigger on push, merge, or PR.
-- Give the build job `id-token: write`.
+- Add a trigger that publishes on a push to a branch, or on a merge. The
+  labelled-PR trigger is deliberate and only ever produces `0.0.0-experimental`
+  builds; nothing may reach the `latest` tag without a human pressing publish.
+- Change the PR trigger from `pull_request_target` to `pull_request`.
+- Give the build job `id-token: write`, an environment, or any secret.
 - Remove the version-shape assertion.
+- Add a second workflow file that publishes.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,21 @@ on:
   release:
     types: [published]
 
+  # Label a pull request `publish-experimental` and it publishes an
+  # experimental build, republishing on every push to that PR.
+  #
+  # `pull_request_target`, not `pull_request`, and the difference is the whole
+  # security argument: `pull_request` would run the *PR branch's* copy of this
+  # file, with publish credentials in scope. `pull_request_target` runs this
+  # file as it exists on the default branch, so the environment gate and the
+  # version assertion below cannot be edited by the branch being published.
+  #
+  # The usual `pull_request_target` footgun - checking out untrusted code in a
+  # job that holds secrets - does not apply, because the build job below holds
+  # neither secrets nor an id-token.
+  pull_request_target:
+    types: [labeled, synchronize]
+
   workflow_dispatch:
     inputs:
       mode:
@@ -50,13 +65,22 @@ on:
 permissions: {}
 
 concurrency:
-  group: publish-${{ github.event.inputs.mode || 'release' }}
+  # Per pull request for labelled builds, so two PRs do not serialise behind
+  # each other; a single group for real releases, so they never overlap.
+  group: publish-${{ github.event.pull_request.number || github.event.inputs.mode || 'release' }}
   cancel-in-progress: false
 
 jobs:
   build:
     name: Build and pack
     runs-on: ubuntu-latest
+    # Never for forks: a fork PR must not be able to reach the publish job,
+    # and `pull_request_target` would otherwise run for one.
+    if: |
+      github.event_name != 'pull_request_target' || (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'publish-experimental')
+      )
     # Deliberately minimal. This job may run code from an unreviewed branch.
     permissions:
       contents: read
@@ -75,13 +99,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "$EVENT" = "release" ]; then
-            if [ "$IS_PRERELEASE" = "true" ]; then mode=next; else mode=latest; fi
-          else
-            mode="$INPUT_MODE"
-          fi
+          case "$EVENT" in
+            release)
+              if [ "$IS_PRERELEASE" = "true" ]; then mode=next; else mode=latest; fi
+              ;;
+            pull_request_target)
+              # A labelled PR can only ever produce an experimental build.
+              mode=experimental
+              ;;
+            *)
+              mode="$INPUT_MODE"
+              ;;
+          esac
 
-          if [ "$mode" = "experimental" ]; then
+          if [ "$mode" = "experimental" ] && [ "$EVENT" = "workflow_dispatch" ]; then
             # Never interpolated into a shell or a ref without passing this.
             # Branch names are attacker-chosen in the threat model this
             # workflow exists for.
@@ -103,8 +134,17 @@ jobs:
         if: steps.plan.outputs.mode != 'experimental'
         uses: actions/checkout@v7
 
+      # Pinned to the exact head sha, not the branch name: a branch can move
+      # between the label event and the checkout.
+      - name: Check out the pull request
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
       - name: Check out the branch under test
-        if: steps.plan.outputs.mode == 'experimental'
+        if: steps.plan.outputs.mode == 'experimental' && github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.target_branch }}
@@ -124,7 +164,10 @@ jobs:
       - name: Stamp an experimental version
         if: steps.plan.outputs.mode == 'experimental'
         env:
-          SHA: ${{ github.sha }}
+          # The sha of the code actually being built. For a labelled PR that is
+          # the PR head, not github.sha - which under pull_request_target is the
+          # base branch, and would stamp a version nobody could correlate.
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: node scripts/stamp-experimental-version.mjs
 
       - name: Build
@@ -166,6 +209,8 @@ jobs:
       # The only job with a publish-capable token.
       id-token: write
       contents: read
+      # To post the install instructions back onto a labelled pull request.
+      pull-requests: write
     environment: npm-${{ needs.build.outputs.mode }}
     steps:
       - uses: actions/setup-node@v7
@@ -228,6 +273,46 @@ jobs:
             echo "publishing $(basename "$tgz") to @$DIST_TAG"
             npm publish "$tgz" --tag "$DIST_TAG"
           done
+
+      # Tells the PR author how to install what was just published. The
+      # experimental dist-tag is clobbered by the next build, so the comment
+      # gives the exact version, which is stable.
+      - name: Comment on the pull request
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        with:
+          script: |
+            const version = process.env.VERSION;
+            const marker = '<!-- experimental-build -->';
+            const body = [
+              marker,
+              '## Experimental build',
+              '',
+              '| | |',
+              '|---|---|',
+              '| **Version** | `' + version + '` |',
+              '| **Dist tag** | `experimental` |',
+              '| **Commit** | ' + context.payload.pull_request.head.sha.slice(0, 7) + ' |',
+              '',
+              '```bash',
+              'npm install @strapi-community/plugin-rest-cache@' + version,
+              '```',
+              '',
+              'Install by exact version. The `experimental` tag moves with every build.',
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const mine = existing.data.find((c) => c.body?.includes(marker));
+
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
       - name: Summary
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,244 @@
+# Publishes to npm. Never automatically.
+#
+# There is no trigger here that fires on a merge, and there must never be one.
+# Every path requires a human: either pressing "Publish release" on a draft
+# Release, or dispatching this workflow, and then approving the deployment
+# environment.
+#
+# ---------------------------------------------------------------------------
+# Why this is split into two jobs
+# ---------------------------------------------------------------------------
+# npm trusted publishing is NOT branch-scoped. It validates the repository,
+# the workflow *filename*, and optionally the environment - it discards the
+# `@refs/heads/...` part of the ref entirely. And `workflow_dispatch` runs the
+# workflow file from the branch you select.
+#
+# So "dispatch this workflow on a feature branch" would hand that branch's own
+# YAML a publish-capable OIDC token, and `npm publish` defaults to `--tag
+# latest`. That is a real release published from unreviewed code.
+#
+# Instead: this workflow is only ever dispatched on the default branch, and the
+# branch to build is passed as an *input*. The build job checks out that branch
+# and has no id-token and no environment, so it cannot publish anything. The
+# publish job runs from this file, gated by an environment whose deployment
+# branch rule the dispatching ref actually satisfies.
+#
+# The version-shape assertion in the publish job is the other half: build-job
+# code is untrusted, so it could stamp `5.99.0` and have it resolve for
+# everyone on `^5.0.0` regardless of dist-tag. The assertion lives in the
+# publish job, whose YAML comes from the default branch.
+name: publish
+
+on:
+  # Fired when a maintainer presses "Publish release" on a draft Release that
+  # release-please prepared.
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: What to publish
+        type: choice
+        options: [latest, next, experimental]
+        default: experimental
+      target_branch:
+        description: Branch to build (experimental mode only)
+        type: string
+        required: false
+
+permissions: {}
+
+concurrency:
+  group: publish-${{ github.event.inputs.mode || 'release' }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and pack
+    runs-on: ubuntu-latest
+    # Deliberately minimal. This job may run code from an unreviewed branch.
+    permissions:
+      contents: read
+    outputs:
+      mode: ${{ steps.plan.outputs.mode }}
+      version: ${{ steps.version.outputs.version }}
+      dist_tag: ${{ steps.plan.outputs.dist_tag }}
+    steps:
+      - name: Work out what is being published
+        id: plan
+        env:
+          EVENT: ${{ github.event_name }}
+          INPUT_MODE: ${{ github.event.inputs.mode }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT" = "release" ]; then
+            if [ "$IS_PRERELEASE" = "true" ]; then mode=next; else mode=latest; fi
+          else
+            mode="$INPUT_MODE"
+          fi
+
+          if [ "$mode" = "experimental" ]; then
+            # Never interpolated into a shell or a ref without passing this.
+            # Branch names are attacker-chosen in the threat model this
+            # workflow exists for.
+            if ! printf '%s' "$TARGET_BRANCH" | grep -Eq '^[A-Za-z0-9._/-]{1,200}$'; then
+              echo "::error::target_branch is missing or has unexpected characters"
+              exit 1
+            fi
+            case "$TARGET_BRANCH" in
+              -*|*..*) echo "::error::target_branch rejected"; exit 1 ;;
+            esac
+          fi
+
+          {
+            echo "mode=$mode"
+            echo "dist_tag=$mode"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out the release commit
+        if: steps.plan.outputs.mode != 'experimental'
+        uses: actions/checkout@v7
+
+      - name: Check out the branch under test
+        if: steps.plan.outputs.mode == 'experimental'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.target_branch }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          # npm >= 11.5.1 is required for trusted publishing, and no Node 22
+          # release ships one.
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Stamp an experimental version
+        if: steps.plan.outputs.mode == 'experimental'
+        env:
+          SHA: ${{ github.sha }}
+        run: node scripts/stamp-experimental-version.mjs
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Pack
+        id: pack
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          # `pnpm pack`, not `npm pack`: npm has no concept of the workspace:
+          # protocol and would publish `workspace:*` literally, producing a
+          # manifest nobody can install. pnpm rewrites it to a real range.
+          for dir in packages/*/; do
+            [ -f "$dir/package.json" ] || continue
+            (cd "$dir" && pnpm pack --pack-destination "$GITHUB_WORKSPACE/artifacts")
+          done
+          ls -1 artifacts
+
+      - name: Record the version
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./packages/plugin-rest-cache/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-tarballs
+          path: artifacts/*.tgz
+          retention-days: 7
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      # The only job with a publish-capable token.
+      id-token: write
+      contents: read
+    environment: npm-${{ needs.build.outputs.mode }}
+    steps:
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-tarballs
+          path: artifacts
+
+      - name: Check npm is new enough for trusted publishing
+        run: |
+          set -euo pipefail
+          installed=$(npm --version)
+          echo "npm $installed"
+          # Trusted publishing needs >= 11.5.1. Failing here with a clear
+          # message beats failing inside `npm publish` with an auth error.
+          required=11.5.1
+          lowest=$(printf '%s\n%s\n' "$installed" "$required" | sort -V | head -1)
+          if [ "$lowest" != "$required" ]; then
+            echo "::error::npm >= $required required for trusted publishing, found $installed"
+            exit 1
+          fi
+
+      - name: Assert the versions are the shape this mode allows
+        env:
+          MODE: ${{ needs.build.outputs.mode }}
+        run: |
+          set -euo pipefail
+          # The build job may have run unreviewed code, so nothing it produced
+          # is trusted - including the version it stamped. Without this, a
+          # poisoned build could publish 5.99.0, which every `^5.0.0` range
+          # would resolve no matter which dist-tag it carried.
+          fail=0
+          for tgz in artifacts/*.tgz; do
+            version=$(tar -xzOf "$tgz" package/package.json | node -p 'JSON.parse(require("fs").readFileSync(0,"utf8")).version')
+            echo "$(basename "$tgz"): $version"
+            case "$MODE" in
+              experimental)
+                printf '%s' "$version" | grep -Eq '^0\.0\.0-experimental\.[0-9a-f]{40}$' || { echo "::error::$tgz is not an experimental version"; fail=1; } ;;
+              next)
+                printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+$' || { echo "::error::$tgz is not a prerelease version"; fail=1; } ;;
+              latest)
+                printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo "::error::$tgz is not a stable version"; fail=1; } ;;
+            esac
+          done
+          [ "$fail" -eq 0 ]
+
+      - name: Publish
+        env:
+          DIST_TAG: ${{ needs.build.outputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          # No NODE_AUTH_TOKEN: authentication is OIDC via trusted publishing,
+          # and provenance is generated automatically. publishConfig in each
+          # package.json also sets provenance, as insurance.
+          for tgz in artifacts/*.tgz; do
+            echo "publishing $(basename "$tgz") to @$DIST_TAG"
+            npm publish "$tgz" --tag "$DIST_TAG"
+          done
+
+      - name: Summary
+        env:
+          MODE: ${{ needs.build.outputs.mode }}
+          DIST_TAG: ${{ needs.build.outputs.dist_tag }}
+        run: |
+          {
+            echo "### Published"
+            echo
+            echo "- mode: \`$MODE\`"
+            echo "- dist-tag: \`$DIST_TAG\`"
+            echo
+            echo 'Verify with `npm audit signatures` after installing.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,61 @@
+# Maintains a rolling "chore: release X.Y.Z" pull request and, when it is
+# merged, a DRAFT GitHub Release per package.
+#
+# This workflow never publishes anything. release-please has no publish code
+# path at all - that is why it was chosen. Publishing is `publish.yml`, and it
+# only ever runs when a human presses a button.
+#
+# The draft is deliberate and load-bearing. A Release created with the default
+# GITHUB_TOKEN does not trigger other workflows, so an auto-published release
+# would silently fail to publish to npm. Requiring a maintainer to press
+# "Publish release" both fixes that and is the first of the two human gates.
+name: release-please
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The CLI rather than the action: googleapis/release-please-action has
+      # had no commits since 2026-05, while the CLI is current.
+      - name: Run release-please
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx --yes release-please@17 release-pr \
+            --token "$GITHUB_TOKEN" \
+            --repo-url "$GITHUB_REPOSITORY" \
+            --config-file release-please-config.json \
+            --manifest-file .release-please-manifest.json
+
+          npx --yes release-please@17 github-release \
+            --token "$GITHUB_TOKEN" \
+            --repo-url "$GITHUB_REPOSITORY" \
+            --config-file release-please-config.json \
+            --manifest-file .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "packages/plugin-rest-cache": "5.0.1",
+  "packages/provider-rest-cache-memory": "5.0.0",
+  "packages/provider-rest-cache-redis": "5.0.0"
+}

--- a/packages/plugin-rest-cache/package.json
+++ b/packages/plugin-rest-cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi-community/plugin-rest-cache",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Speed-up HTTP requests with LRU cache",
   "license": "MIT",
   "strapi": {
@@ -131,5 +131,9 @@
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/provider-rest-cache-memory/package.json
+++ b/packages/provider-rest-cache-memory/package.json
@@ -51,7 +51,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/strapi-community/plugin-rest-cache.git",
-    "directory": "packages/plugin-rest-cache"
+    "directory": "packages/provider-rest-cache-memory"
   },
   "bugs": {
     "url": "https://github.com/strapi-community/plugin-rest-cache/issues"
@@ -86,5 +86,9 @@
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/provider-rest-cache-redis/package.json
+++ b/packages/provider-rest-cache-redis/package.json
@@ -51,7 +51,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/strapi-community/plugin-rest-cache.git",
-    "directory": "packages/plugin-rest-cache"
+    "directory": "packages/provider-rest-cache-redis"
   },
   "bugs": {
     "url": "https://github.com/strapi-community/plugin-rest-cache/issues"
@@ -87,5 +87,9 @@
   },
   "engines": {
     "node": ">=20.0.0 <=26.x.x"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "separate-pull-requests": false,
+  "group-pull-request-title-pattern": "chore: release ${version}",
+  "pull-request-title-pattern": "chore: release ${version}",
+  "draft": true,
+  "prerelease-type": "beta",
+  "plugins": [
+    "node-workspace"
+  ],
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance"
+    },
+    {
+      "type": "refactor",
+      "section": "Refactoring"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation"
+    },
+    {
+      "type": "build",
+      "section": "Build System"
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "chore",
+      "section": "Chores",
+      "hidden": true
+    }
+  ],
+  "packages": {
+    "packages/plugin-rest-cache": {
+      "component": "plugin-rest-cache"
+    },
+    "packages/provider-rest-cache-memory": {
+      "component": "provider-rest-cache-memory"
+    },
+    "packages/provider-rest-cache-redis": {
+      "component": "provider-rest-cache-redis"
+    }
+  },
+  "last-release-sha": "6407e61f4c89863c84e542bc2a92a07801ff4f9a"
+}

--- a/scripts/stamp-experimental-version.mjs
+++ b/scripts/stamp-experimental-version.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Stamp every publishable package with an experimental version.
+ *
+ * Version scheme: `0.0.0-experimental.<40-char sha>`.
+ *
+ * The `0.0.0-` prefix is what actually protects users, not the dist-tag.
+ * `^5.1.0` desugars to `>=5.1.0 <6.0.0`, and a major of 0 fails that lower
+ * bound; separately, npm never matches a prerelease unless the range itself
+ * carries a prerelease on the same major.minor.patch tuple. Two independent
+ * reasons an experimental build cannot be selected by an ordinary range.
+ *
+ * A scheme like `5.1.0-experimental.<sha>` would sit on the 5.1.0 tuple and
+ * could be pulled in by `^5.1.0-0` or by a transitive prerelease-tolerant
+ * range. Do not switch to it.
+ *
+ * Internal peer ranges have to be rewritten too. `workspace:^` packs to
+ * `^5.0.1`, which cannot satisfy `0.0.0-experimental.*` - no range notation
+ * can express "any 5.x stable OR this experimental build" - so installing the
+ * result would ERESOLVE. Each internal reference is pinned to the exact
+ * experimental version instead.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PACKAGES = join(ROOT, 'packages');
+
+const sha = process.env.SHA ?? '';
+
+if (!/^[0-9a-f]{40}$/.test(sha)) {
+  console.error(`SHA must be a full 40-character commit sha, got: ${JSON.stringify(sha)}`);
+  process.exit(1);
+}
+
+const version = `0.0.0-experimental.${sha}`;
+
+const manifests = readdirSync(PACKAGES)
+  .map((name) => join(PACKAGES, name, 'package.json'))
+  .filter((file) => existsSync(file));
+
+const names = new Set(
+  manifests.map((file) => JSON.parse(readFileSync(file, 'utf8')).name)
+);
+
+for (const file of manifests) {
+  const pkg = JSON.parse(readFileSync(file, 'utf8'));
+
+  pkg.version = version;
+
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    const deps = pkg[field];
+    if (!deps) continue;
+
+    for (const dep of Object.keys(deps)) {
+      if (names.has(dep)) {
+        deps[dep] = version;
+      }
+    }
+  }
+
+  writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(`${pkg.name} -> ${version}`);
+}


### PR DESCRIPTION
Three publish paths, **no automatic ones**. Nothing here fires on a merge, and nothing that does should ever be added.

## Shape

| Path | Trigger | dist-tag | Environment |
|---|---|---|---|
| Production | Human presses **Publish release** on a draft | `latest` | `npm-latest` |
| Pre-release | Same, with the Release marked as a pre-release | `next` | `npm-prerelease` |
| Experimental | `workflow_dispatch` **on main**, branch as an input | `experimental` | `npm-experimental` |

Two human gates on every path: publishing the draft (or dispatching), then approving the deployment environment.

## Changelog: release-please

Chosen over changesets for two **structural** reasons, not configurable ones:

- It groups the changelog **by change type** from the conventional commits you already write. Changesets *cannot* — the format is hard-coded to Major/Minor/Patch and a changeset file carries no type.
- It has **no publish code path at all**. Manual publishing is its design, not a workaround.

Contributors do nothing extra — no changeset files to write alongside commits.

The **draft release is load-bearing**, not ceremony: a Release created with `GITHUB_TOKEN` does not trigger other workflows, so an auto-published one would silently never reach npm.

## Auth: trusted publishing, not a token

npm **revoked all classic tokens in Dec 2025**, and granular tokens now cap at **90 days**. A token-based workflow is a permanent rotation chore. OIDC removes the secret entirely and brings provenance with it.

## The experimental path, and why it looks convoluted

**npm trusted publishing is not branch-scoped.** It validates repository + workflow *filename* + environment, and discards the ref. `workflow_dispatch` runs the workflow file **from the branch you select**.

So the obvious design — dispatch this on a feature branch — hands that branch's own YAML a publish-capable token, and `npm publish` defaults to `--tag latest`. **That's a real release cut from unreviewed code.** It's the Nx/TanStack incident shape.

Instead:

```
dispatch on main, target_branch as an INPUT
 ├─ build job    : checks out that branch. NO id-token, NO environment.
 │                 Can poison the tarball — which is the point — but cannot publish.
 └─ publish job  : runs from main's YAML. Environment-gated (branch rule actually
                   holds, because github.ref really is main). Asserts every
                   tarball's version shape before publishing.
```

Both halves are needed. Without the assertion, a poisoned build could stamp `5.99.0` — which every `^5.0.0` range resolves **regardless of dist-tag**.

Experimental versions are `0.0.0-experimental.<sha>`. The `0.0.0-` prefix is what protects users, not the dist-tag: a major of 0 fails any caret range's lower bound, and npm won't match a prerelease across tuples. `5.1.0-experimental.<sha>` would be *unsafe* — it sits on the 5.1.0 tuple.

## Two things that would have broken the first release

Both found and verified while building this:

1. **`npm publish` doesn't understand `workspace:`.** The plugin depends on the memory provider as `workspace:*` **at runtime**. I packed it: `pnpm pack` rewrites it to a real version, `npm publish` would ship the literal string and the package would be uninstallable. The workflow packs first and publishes tarballs.
2. **Internal peer ranges break experimental installs.** `workspace:^` packs to `^5.0.1`, which cannot satisfy `0.0.0-*` — no range can express "any 5.x OR this experimental". Installing would `ERESOLVE`. The stamping script pins them to the exact version.

## Verified locally

- Stamping rewrites all three manifests **including peer deps**
- `pnpm pack` resolves every internal reference to the exact experimental version
- All four version assertions behave — including **rejecting a 5.99.0 tarball in experimental mode**

Plugin version synced to **5.0.1** (what's actually on npm) so release-please computes from the right base. Next release lands as **5.1.0**.

## ⚠️ This will not work until you do the npm and GitHub setup

Details in the next comment — three trusted-publisher configs and three environments. **Do not merge and assume it works**; the first production release should be a dry run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)