### PR TITLE
chore(deps): hold back TypeScript and Redux Toolkit majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,20 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "jest"
         update-types: ["version-update:semver-major"]
+
+      # TypeScript 7 is the native port and does not expose the JavaScript
+      # compiler API, so ts-jest cannot use it:
+      #   The TypeScript compiler "typescript" (version 7.0.2) does not expose
+      #   the JavaScript compiler API required by ts-jest
+      # Every e2e suite fails to even start. Revisit when ts-jest supports it.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
+      # The admin imports Strapi's own RTK Query instance, and Strapi ships
+      # @reduxjs/toolkit 1.9.x. This is a devDependency only so declaration
+      # emit can name the types; resolving a different major than the one the
+      # admin actually runs on is how those types stop matching.
+      - dependency-name: "@reduxjs/toolkit"
         update-types: ["version-update:semver-major"]
 
       # chalk 5+ is ESM-only and cannot be require()d from the CommonJS server


### PR DESCRIPTION
Dependabot's grouped dev-tooling PR (#191) fails every e2e suite. Cause:

```
The TypeScript compiler "typescript" (version 7.0.2) does not expose the
JavaScript compiler API required by ts-jest
```

TypeScript 7 is the **native (Go) port**. `ts-jest` can't load it, so no test suite even starts. That's an ecosystem constraint, not something to work around here — held back until ts-jest supports it.

Also holding back **`@reduxjs/toolkit`** majors. It's a devDependency purely so declaration emit can name the types RTK Query infers ([#181](https://github.com/strapi-community/plugin-rest-cache/pull/181) — the TS2742 fix). The admin uses *Strapi's* instance, and Strapi ships 1.9.x; resolving a different major than the code actually runs on is how those types quietly stop matching.

## Also fixes a bug I introduced

The lerna removal in #186 used a regex that deleted the `dependency-name` line but left its `update-types` behind, which then attached to the preceding rule:

```yaml
- dependency-name: "jest"
  update-types: ["version-update:semver-major"]
  update-types: ["version-update:semver-major"]   # ← orphan from lerna
```

Harmless in practice (duplicate key, last wins) but wrong, and it would have confused the next person to read it.

## What happens to #191

Closing it. Once this merges, Dependabot regroups without the TypeScript and RTK majors, and the remaining eight bumps — `0x`, `autocannon`, `cpy-cli`, `lint-staged`, `@types/koa`, `@types/node`, `prettier`, `supertest` — come back as a PR that can actually go green.

Worth noting `prettier` 2 → 3 is in that set. The providers were on `^2` and will reformat; that's expected and you'd flagged prettier as safe to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)