### PR TITLE
feat(bench): measure conditional requests and unique-key workloads

### DIFF
--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -75,6 +75,27 @@ const SCENARIOS = [
     name: "Cache enabled, ETag on",
     env: { ENABLE_CACHE: "true", ENABLE_ETAG: "true" },
   },
+  {
+    id: "cache-conditional",
+    name: "Cache enabled, conditional requests (304)",
+    env: { ENABLE_CACHE: "true", ENABLE_ETAG: "true" },
+    // What a browser or CDN actually does on a revalidation: send the ETag
+    // and expect an empty 304. Measured separately because it skips both the
+    // body read from the store and the body write to the socket, so folding it
+    // into the ETag-on number would flatter that scenario.
+    conditional: true,
+    expectStatus: 304,
+  },
+  {
+    id: "cache-unique-keys",
+    name: "Cache enabled, every request a distinct key",
+    env: { ENABLE_CACHE: "true", ENABLE_ETAG: "false" },
+    // The honest downside. Query parameters are part of the cache key, so an
+    // API called with a different filter every time stores an entry per
+    // request and reads none of them back. This is the cost of caching when
+    // caching cannot help, and it is what a high-cardinality API looks like.
+    uniqueKeys: true,
+  },
 ];
 
 async function waitForServer(url, timeoutMs = 180000) {
@@ -136,6 +157,27 @@ function run(opts) {
   });
 }
 
+/**
+ * Fetch the ETag the server currently holds for a path.
+ *
+ * Used by the conditional scenario, which has to send a *matching*
+ * If-None-Match to exercise the 304 path. A made-up value would miss and
+ * measure an ordinary cache hit instead - the scenario would pass while
+ * measuring the wrong thing.
+ */
+async function currentEtag(url) {
+  const response = await fetch(url);
+  const etag = response.headers.get("etag");
+
+  if (!etag) {
+    throw new Error(
+      `expected an ETag from ${url} - is enableEtag on for this scenario?`
+    );
+  }
+
+  return etag;
+}
+
 async function benchmarkScenario(scenario, args) {
   const url = `http://127.0.0.1:${args.port}${args.path}`;
 
@@ -149,13 +191,53 @@ async function benchmarkScenario(scenario, args) {
     process.stdout.write(`[bench]   warmup ${args.warmup}s\n`);
     await run({ url, connections: 10, duration: args.warmup });
 
+    const extra = {};
+
+    if (scenario.conditional) {
+      const etag = await currentEtag(url);
+      process.stdout.write(`[bench]   revalidating against ${etag}\n`);
+      extra.headers = { "if-none-match": etag };
+      extra.expectBody = undefined;
+    }
+
+    if (scenario.uniqueKeys) {
+      // A distinct query parameter per request, so every one misses and stores
+      // a new entry.
+      //
+      // Not autocannon's `idReplacement`: that only substitutes inside the
+      // request *body*, so it left every request hitting the same URL. The
+      // scenario then measured cache hits and reported them as misses - it
+      // came out faster than the plain cache-on scenario, which is what gave
+      // it away.
+      const separator = args.path.includes("?") ? "&" : "?";
+      let counter = 0;
+
+      extra.requests = [
+        {
+          setupRequest(request) {
+            counter += 1;
+            return { ...request, path: `${args.path}${separator}bench=${counter}` };
+          },
+        },
+      ];
+    }
+
     process.stdout.write(`[bench]   measuring ${args.duration}s\n`);
     const result = await run({
       url,
       connections: args.connections,
       pipelining: args.pipelining,
       duration: args.duration,
+      ...extra,
     });
+
+    // A scenario that silently stopped exercising what it claims to is worse
+    // than no scenario. 304s report as non-2xx, so check them explicitly.
+    if (scenario.expectStatus === 304 && result.non2xx === 0) {
+      throw new Error(
+        `${scenario.id}: expected 304 responses, saw none - the conditional request is not revalidating`
+      );
+    }
 
     return {
       id: scenario.id,
@@ -223,7 +305,14 @@ function toMarkdown(results, args, meta) {
   );
   lines.push("");
 
-  const unreliable = results.filter((r) => r.errors + r.timeouts + r.non2xx > 0);
+  const expectedNon2xx = new Set(
+    SCENARIOS.filter((s) => s.expectStatus === 304).map((s) => s.id)
+  );
+  const unreliable = results.filter(
+    (r) =>
+      r.errors + r.timeouts > 0 ||
+      (r.non2xx > 0 && !expectedNon2xx.has(r.id))
+  );
   if (unreliable.length) {
     const baselineFailed = unreliable.some((r) => r.id === "cache-disabled");
     lines.push("> [!WARNING]");
@@ -323,7 +412,14 @@ async function main() {
   if (args.markdown) writeFileSync(args.markdown, `${markdown}\n`);
   if (!args.json && !args.markdown) process.stdout.write(`\n${markdown}\n`);
 
-  const failed = results.filter((r) => r.errors || r.timeouts || r.non2xx);
+  // A conditional request answers 304, which autocannon counts as non-2xx.
+  // Flagging it as a fault every run trains people to ignore the warning.
+  const expected304 = new Set(
+    SCENARIOS.filter((s) => s.expectStatus === 304).map((s) => s.id)
+  );
+  const failed = results.filter(
+    (r) => r.errors || r.timeouts || (r.non2xx && !expected304.has(r.id))
+  );
   if (failed.length) {
     for (const r of failed) {
       process.stdout.write(


### PR DESCRIPTION
Two scenarios beyond cache-on/cache-off, both describing situations users actually have.

| Scenario | rps | vs reference |
|---|---:|---:|
| Cache disabled (reference) | 234 | 1.00× |
| Cache enabled, ETag off | 663 | 2.83× |
| Cache enabled, ETag on | 643 | 2.74× |
| **Conditional requests (304)** | 701 | **2.99×** |
| **Every request a distinct key** | 236 | **1.01×** |

*(5s/scenario on a dev machine — indicative only. The workflow is what produces publishable numbers.)*

**Conditional requests** — what a browser or CDN does on revalidation: send the ETag, get an empty 304. Measured separately because it skips both the store read and the body write, so folding it into the ETag-on number would flatter that figure. It fetches the *live* ETag first; a made-up one would miss and quietly measure an ordinary cache hit.

**Every request a distinct key** — the honest downside. Query params are part of the cache key, so an API called with a different filter each time stores an entry per request and reads none back. Landing at **1.01×** is the useful result: caching a high-cardinality workload costs almost nothing and buys almost nothing.

## The second scenario was wrong, and the numbers said so

First run reported it at **2.7× — faster than a plain cache hit**. That's impossible if every request were really missing. Cause: autocannon's `idReplacement` only substitutes inside the request *body*, not the URL, so every request went to the same path and measured cache hits. Now varies the path via `setupRequest`.

Worth noting the benchmark would have "passed" either way. The only reason it got caught is that the number was implausible on its face.

## Also: stop reporting 304s as failures

autocannon counts a 304 as non-2xx, so both the console warning and the *"these numbers are not trustworthy"* banner fired on every run — which is how people learn to ignore warnings. The scenario now **asserts it sees 304s**, so a revalidation that silently stops revalidating still fails loudly.

## Not included

Regenerating `BENCHMARKS.md` — that needs the workflow on a quiet runner, and it should run from this branch once merged so the new scenarios are included. Happy to trigger it after, or you can from the Actions tab (`benchmarks` → `update_docs: true` opens a PR with the rewritten file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)