### PR TITLE
fix: resolve cache providers from the Strapi application root

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,38 @@ jobs:
 
       - run: pnpm run test:lint
 
+  # Boots each playground in a real child process.
+  #
+  # Every other suite boots Strapi inside jest, whose module resolver is far
+  # more permissive than Node's. The plugin resolves its cache provider by
+  # package name at boot, so a provider jest can find but Node cannot gives a
+  # completely green build for an application that cannot start. That is not
+  # hypothetical - it is how the redis provider became unresolvable under pnpm
+  # while e2e_redis stayed green.
+  boot_smoke:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: bitnami/redis:latest
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - run: pnpm run build
+
+      - run: pnpm run test:boot
+
   e2e_memory:
     runs-on: ubuntu-latest
     strategy:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "watch:plugin:rest-cache": "pnpm --filter @strapi-community/plugin-rest-cache run watch",
     "watch:link:plugin:rest-cache": "pnpm --filter @strapi-community/plugin-rest-cache run watch:link",
     "test:smoke": "node scripts/provider-smoke.cjs",
+    "test:boot": "node scripts/boot-smoke.mjs",
     "test:deps": "node scripts/check-undeclared-deps.cjs",
     "lint:workspaces": "pnpm -r run test:lint",
     "test:cluster": "node scripts/redis-cluster-check.cjs",

--- a/packages/plugin-rest-cache/server/src/bootstrap.ts
+++ b/packages/plugin-rest-cache/server/src/bootstrap.ts
@@ -1,5 +1,6 @@
 import type { Core } from '@strapi/strapi';
 import { createRequire } from 'module';
+import path from 'path';
 
 import colors from './utils/colors';
 import permissionsActions from './permissions-actions';
@@ -41,14 +42,29 @@ const createProvider = async (
 
   const packageName = `@strapi-community/provider-rest-cache-${providerName}`;
 
-  // Resolve and load through the same require.
+  // Resolve from the Strapi application first, then from this plugin.
   //
-  // This used to call the bare `require.resolve`, which survives verbatim into
-  // the ESM half of this dual package - and `require` does not exist in an ES
-  // module. The resulting ReferenceError carries no `code`, so the handler
-  // below rethrew it and the plugin failed to boot for anyone whose runtime
-  // took the `import` branch of the exports map.
-  const requireProvider = createRequire(import.meta.url);
+  // The application is where a provider is actually installed - users run
+  // `npm install @strapi-community/provider-rest-cache-redis` in their project,
+  // not inside this package. Resolving only from here happens to work under
+  // npm and yarn, whose flat node_modules hoists the provider somewhere a
+  // walk up from this file finds it. Under pnpm's strict layout it does not,
+  // and the plugin fails to boot with a MODULE_NOT_FOUND for a package that is
+  // plainly installed.
+  //
+  // The e2e suite cannot catch that: it boots Strapi inside jest, whose
+  // resolver is far more permissive than Node's. `scripts/boot-smoke.mjs`
+  // boots a real child process for exactly this reason.
+  //
+  // Note both of these are `createRequire`, not a bare `require.resolve`. The
+  // latter survives verbatim into the ESM half of this dual package, where
+  // `require` does not exist, and the resulting ReferenceError carries no
+  // `code`, so the handler below rethrew it - the plugin failed to boot for
+  // anyone whose runtime took the `import` branch of the exports map.
+  const requireFromPlugin = createRequire(import.meta.url);
+  const requireFromApp = strapi.dirs?.app?.root
+    ? createRequire(path.join(strapi.dirs.app.root, 'package.json'))
+    : requireFromPlugin;
 
   let modulePath: string;
   let resolved = false;
@@ -57,15 +73,26 @@ const createProvider = async (
      * @todo Allow custom providers installed from npm.
      * Right now it will only load providers from the `@strapi-community` namespace.
      */
-    modulePath = requireProvider.resolve(packageName);
+    modulePath = requireFromApp.resolve(packageName);
     resolved = true;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
+    if ((error as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') throw error;
+
+    try {
+      // The memory provider is a dependency of this plugin rather than of the
+      // application, so it resolves here and not above.
+      modulePath = requireFromPlugin.resolve(packageName);
+      resolved = true;
+    } catch (fallbackError) {
+      if ((fallbackError as NodeJS.ErrnoException).code !== 'MODULE_NOT_FOUND') throw fallbackError;
       modulePath = providerName;
-    } else {
-      throw error;
     }
   }
+
+  // Once resolved, modulePath is absolute and either require loads it. The bare
+  // provider name only survives when nothing resolved, and that escape hatch
+  // means a package the *application* installed.
+  const requireProvider = requireFromApp;
   try {
     provider = requireProvider(modulePath);
   } catch (err) {

--- a/scripts/boot-smoke.mjs
+++ b/scripts/boot-smoke.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+/**
+ * Boots each playground in a real child process and asserts it comes up.
+ *
+ * This exists because of a blind spot that let a release-blocking bug reach
+ * `main`: every e2e test boots Strapi *inside jest*, and jest resolves modules
+ * with its own resolver, which searches upwards far more liberally than Node
+ * does. The plugin resolves its cache provider by package name at boot, so a
+ * provider that jest can find but Node cannot produces a suite that is entirely
+ * green while `strapi start` fails on the very first request.
+ *
+ * That is not hypothetical - it is exactly how the redis provider shipped
+ * unresolvable under pnpm while `e2e_redis` passed. See the resolution comment
+ * in server/src/bootstrap.ts.
+ *
+ * So: no jest, no test framework, no mocks. A real `node` process, the real
+ * boot path, real Node resolution.
+ *
+ * Usage: node scripts/boot-smoke.mjs [--provider memory|redis|both]
+ */
+
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const READY_TIMEOUT_MS = 180000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+  const args = { provider: 'both' };
+  for (let i = 2; i < argv.length; i += 1) {
+    if (argv[i] === '--provider') {
+      args.provider = argv[i + 1];
+      i += 1;
+    }
+  }
+  if (!['memory', 'redis', 'both'].includes(args.provider)) {
+    throw new Error(`unknown provider "${args.provider}"`);
+  }
+  return args;
+}
+
+async function waitForReady(url, child, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    // A crashed boot is the interesting case, and it is the one where polling
+    // an HTTP port tells you nothing for the full timeout. Fail immediately
+    // instead, so the provider error is what gets reported rather than a
+    // generic "did not become ready".
+    if (child.exitCode !== null) {
+      throw new Error(`server exited with code ${child.exitCode} before becoming ready`);
+    }
+    try {
+      const res = await fetch(url);
+      if (res.status < 500) return;
+    } catch {
+      // not up yet
+    }
+    await sleep(500);
+  }
+
+  throw new Error(`server did not become ready within ${timeoutMs}ms`);
+}
+
+async function bootPlayground(provider, port) {
+  const logs = [];
+
+  const child = spawn(process.execPath, ['start-profiler.js'], {
+    cwd: path.join(ROOT, 'playgrounds', provider),
+    env: {
+      ...process.env,
+      PORT: String(port),
+      HOST: '127.0.0.1',
+      STRAPI_DISABLE_UPDATE_NOTIFICATION: 'true',
+      STRAPI_HIDE_STARTUP_MESSAGE: 'true',
+      STRAPI_TELEMETRY_DISABLED: 'true',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  child.stdout.on('data', (d) => logs.push(d.toString()));
+  child.stderr.on('data', (d) => logs.push(d.toString()));
+
+  try {
+    await waitForReady(`http://127.0.0.1:${port}/_health`, child, READY_TIMEOUT_MS);
+    return { ok: true, logs };
+  } catch (error) {
+    return { ok: false, logs, error };
+  } finally {
+    if (child.exitCode === null) {
+      child.kill('SIGTERM');
+      const deadline = Date.now() + 15000;
+      while (child.exitCode === null && Date.now() < deadline) {
+        await sleep(200);
+      }
+      if (child.exitCode === null) child.kill('SIGKILL');
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const providers = args.provider === 'both' ? ['memory', 'redis'] : [args.provider];
+
+  console.log(`boot smoke test - Node ${process.version}\n`);
+
+  const results = [];
+  let port = 2137;
+
+  for (const provider of providers) {
+    process.stdout.write(`  booting ${provider} playground ... `);
+    const result = await bootPlayground(provider, port);
+    port += 1;
+
+    console.log(result.ok ? 'ready' : 'FAILED');
+    if (!result.ok) {
+      console.log(`\n${result.logs.join('')}`);
+      console.log(`  ${result.error.message}\n`);
+    }
+    results.push([result.ok, provider]);
+  }
+
+  console.log('');
+  for (const [ok, provider] of results) {
+    console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${provider} playground boots under real Node resolution`);
+  }
+
+  const failed = results.filter(([ok]) => !ok).length;
+  console.log(`\n${results.length - failed}/${results.length} passed`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## The bug

The redis provider is unresolvable under pnpm. `strapi start` fails at boot:

```
Could not load REST Cache provider "redis". The package
"@strapi-community/provider-rest-cache-redis" could not be resolved.
  Cause: [MODULE_NOT_FOUND] Cannot find module 'redis'
```

The plugin resolved the provider from **its own** location:

```ts
const requireProvider = createRequire(import.meta.url);
requireProvider.resolve('@strapi-community/provider-rest-cache-redis');
```

But a provider is installed in the **application** — users run `npm install
@strapi-community/provider-rest-cache-redis` in their project, not inside this
package. Resolving from the plugin only works when the package manager hoists
the provider somewhere a walk up from the plugin's file finds it. npm and yarn
flatten `node_modules`, so it does. pnpm's strict layout does not.

Verified directly:

```
from APP root  -> resolved: /…/packages/provider-rest-cache-redis/dist/…
from PLUGIN    -> FAILED: MODULE_NOT_FOUND
```

The `Cannot find module 'redis'` in the error is the custom-provider fallback
(`modulePath = providerName`) firing, which is why the message pointed at a
package nobody configured.

## Why CI was green

Every e2e suite boots Strapi **inside jest**, and jest's module resolver
searches far more liberally than Node's. `e2e_redis` passes on all three Node
versions while a real `strapi start` cannot boot at all. The only thing that
caught this was the benchmark workflow, which spawns a real process — and it
surfaced as a 180-second readiness timeout rather than as the provider error.

## The fix

Resolve from the application root first, fall back to the plugin. Both branches
are live: the redis playground declares the provider (application path), the
memory playground does not — it comes from the plugin's own dependencies
(fallback path). So the two smoke runs cover one branch each.

## Closing the blind spot

`scripts/boot-smoke.mjs` boots each playground in a real child process — no
jest, no mocks, real Node resolution — and runs as a new `boot_smoke` CI job.

Before the fix:

```
booting redis playground ... FAILED
  server exited with code 1 before becoming ready
FAIL  redis playground boots under real Node resolution
```

After:

```
PASS  memory playground boots under real Node resolution
PASS  redis playground boots under real Node resolution
```

It reproduces in ~5 seconds, and it fails fast on a crashed boot instead of
polling a dead port for the full timeout, so the provider error is what gets
reported.

## Note

Touches `.github/workflows/tests.yml`, so this needs a maintainer to merge it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)