### PR TITLE
fix: make release-please work and version the packages in lockstep

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,15 @@
   "draft": true,
   "prerelease-type": "beta",
   "plugins": [
-    "node-workspace"
+    {
+      "type": "linked-versions",
+      "groupName": "rest-cache",
+      "components": [
+        "plugin-rest-cache",
+        "provider-rest-cache-memory",
+        "provider-rest-cache-redis"
+      ]
+    }
   ],
   "changelog-sections": [
     {


### PR DESCRIPTION
## release-please has never worked

It has run exactly once on `main` — from #190 — and it **failed**:

```
Error: found cycle in dependency graph:
  @strapi-community/plugin-rest-cache -> @strapi-community/provider-rest-cache-memory
  -> @strapi-community/plugin-rest-cache
    at NodeWorkspace.visitPostOrder (…/plugins/workspace.js:240:19)
```

No release PR exists, and none would ever have been created. This blocks 5.1.0.

## Cause

The plugin depends on the memory provider; both providers depend back on the
plugin for its emitted `/types`. `node-workspace` walks that graph post-order
(`dependencies` + `devDependencies` + `optionalDependencies`) and can never
terminate.

## Fix

Replace `node-workspace` with `linked-versions`. One file, nine lines.

That removes the graph traversal entirely, **and** gives the three packages a
single shared version instead of letting them drift. Without it the dry run
proposed plugin `5.1.0` with both providers at `5.0.1` — confusing for
something installed as a set.

Nothing is lost by dropping `node-workspace`: its job was rewriting internal
dependency ranges, and these packages use the `workspace:` protocol, which
`pnpm pack` already rewrites to the real version when the tarball is built.
That is the mechanism the publish workflow depends on regardless.

## Verified

Same command the workflow runs, pointed at this branch:

```
✔ Replacing strategy for path packages/plugin-rest-cache with forced version: 5.1.0
✔ Replacing strategy for path packages/provider-rest-cache-memory with forced version: 5.1.0
✔ Replacing strategy for path packages/provider-rest-cache-redis with forced version: 5.1.0
Would open 1 pull requests
```

## Known cosmetic issue

The grouped PR title comes out as a bare `chore: release`, with no version.
`plugins/merge.js:73` takes the version from whichever release has path `.`,
and this repo has no root package, so it is `undefined`. Fixing it means adding
the private root package to the release config — a bigger change than belongs
here, and it does not affect the released versions.

## Earlier approach, dropped

The first version of this branch removed the plugin from both providers'
`devDependencies` to break the cycle at the source. That worked (`peerDependencies`
already declares the relationship and pnpm links workspace peers, so `tsc` still
resolved the types), but `linked-versions` makes it unnecessary — and not
churning the providers' manifests right before a release is the safer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)