### PR TITLE
ci: pin every action to a full-length commit SHA

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -93,7 +93,7 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Note: deliberately no `cache: pnpm`. setup-node keys the pnpm store
       # cache on OS + lockfile hash only, with no Node version, so every matrix
@@ -101,9 +101,9 @@ jobs:
       # better-sqlite3 built under one Node ABI gets restored under another and
       # crashes with "Assertion failed: (env) != nullptr". pnpm installs are
       # fast enough that correctness is the better trade.
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
 
@@ -142,7 +142,7 @@ jobs:
           PROVIDER: ${{ matrix.provider }}
         run: cat "bench-$PROVIDER.md" >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmarks-${{ matrix.provider }}
           path: |
@@ -158,9 +158,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: benchmarks-*
           path: artifacts

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # fetch all commits to get last updated time or other git log info
           fetch-depth: 0
@@ -25,10 +25,10 @@ jobs:
       # better-sqlite3 built under one Node ABI gets restored under another and
       # crashes with "Assertion failed: (env) != nullptr". pnpm installs are
       # fast enough that correctness is the better trade.
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           # Strapi 5.52 cannot install below 22.13; docs share the lockfile.
           node-version: '22'
@@ -43,7 +43,7 @@ jobs:
       # please check out the docs of the workflow for more details
       # @see https://github.com/crazy-max/ghaction-github-pages
       - name: Deploy to GitHub Pages
-        uses: crazy-max/ghaction-github-pages@v5
+        uses: crazy-max/ghaction-github-pages@1d6ee9b181a81033a16bd707a1401afa978daab4 # v5
         with:
           # deploy to gh-pages branch
           target_branch: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,27 +132,27 @@ jobs:
 
       - name: Check out the release commit
         if: steps.plan.outputs.mode != 'experimental'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # Pinned to the exact head sha, not the branch name: a branch can move
       # between the label event and the checkout.
       - name: Check out the pull request
         if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Check out the branch under test
         if: steps.plan.outputs.mode == 'experimental' && github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.inputs.target_branch }}
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           # npm >= 11.5.1 is required for trusted publishing, and no Node 22
           # release ships one.
@@ -194,7 +194,7 @@ jobs:
           version=$(node -p "require('./packages/plugin-rest-cache/package.json').version")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: npm-tarballs
           path: artifacts/*.tgz
@@ -213,12 +213,12 @@ jobs:
       pull-requests: write
     environment: npm-${{ needs.build.outputs.mode }}
     steps:
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: npm-tarballs
           path: artifacts
@@ -279,7 +279,7 @@ jobs:
       # gives the exact version, which is stable.
       - name: Comment on the pull request
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           VERSION: ${{ needs.build.outputs.version }}
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,13 +29,13 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,16 +25,16 @@ jobs:
   provider_smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       # Note: deliberately no `cache: pnpm`. setup-node keys the pnpm store
       # cache on OS + lockfile hash only, with no Node version, so every matrix
       # leg shares one store. That store holds compiled native addons, so a
       # better-sqlite3 built under one Node ABI gets restored under another and
       # crashes with "Assertion failed: (env) != nullptr". pnpm installs are
       # fast enough that correctness is the better trade.
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
 
@@ -57,23 +57,23 @@ jobs:
       # but it is exactly where the ESM/interop provider bugs reproduce, so a
       # regression there must fail the build. (Node 18 is EOL and is covered by
       # engines.node ">=20.0.0".)
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 20
       - run: node scripts/provider-smoke.cjs
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
       - run: node scripts/provider-smoke.cjs
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
       - run: node scripts/provider-smoke.cjs
@@ -85,10 +85,10 @@ jobs:
       matrix:
         node: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node }}
 
@@ -108,10 +108,10 @@ jobs:
       matrix:
         node: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node }}
 
@@ -136,10 +136,10 @@ jobs:
   e2e_admin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 22
 
@@ -155,7 +155,7 @@ jobs:
         run: pnpm run test:admin
 
       - if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-output
           path: e2e/.output/
@@ -177,10 +177,10 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
## Why

A tag is a mutable pointer. Anyone who can move `v7` on a third-party action
runs their code in every job in this repo — including `publish`, which holds a
publish-capable OIDC token. Pinning to a SHA is the only thing that makes
"which code ran" answerable after the fact.

## What

All **44** `uses:` references across the five workflows, with the version kept
in a trailing comment so Dependabot can still offer updates and the intended
version stays readable:

```yaml
- uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
```

| Action | Pinned to |
| --- | --- |
| `actions/checkout@v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `actions/setup-node@v7` | `820762786026740c76f36085b0efc47a31fe5020` |
| `actions/upload-artifact@v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/download-artifact@v8` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/download-artifact@v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` |
| `actions/github-script@v7` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` |
| `pnpm/action-setup@v6` | `0977fd99725f1db4007ccb2928dbb4e90d06cc86` |
| `crazy-max/ghaction-github-pages@v5` | `1d6ee9b181a81033a16bd707a1401afa978daab4` |

Every SHA was resolved from the GitHub API for this PR rather than copied from
notes. `pnpm/action-setup@v6` is an **annotated** tag, so the ref points at a
tag object — it is dereferenced to the commit it wraps. Pinning the tag object
SHA would fail at runtime.

Verified: no `uses:` reference outside a 40-hex SHA remains, and all five
workflow files still parse.

This branch was rebuilt on current `main` — the earlier version predated #190
and so did not cover `publish.yml` or `release-please.yml`, the two workflows
where pinning matters most.

## Noticed while doing this

`publish.yml` uses `actions/upload-artifact@v4` and `download-artifact@v4`,
while `tests.yml` and `benchmarks.yml` use `v7` and `v8`. Both are pinned here
as they are; aligning them is a behaviour change to the release path and did
not belong in a pinning PR.

## Follow-up

Once this merges, "Require actions to be pinned to a full-length commit SHA"
can be enabled in the repository's Actions settings to keep it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)