### PR TITLE
fix(bench): isolate redis per scenario and stop counting 304s as failures

### DIFF
--- a/playgrounds/redis/config/plugins.js
+++ b/playgrounds/redis/config/plugins.js
@@ -17,7 +17,16 @@ module.exports = ({ env }) => ({
             // since the cache keys are derived from the request path and are
             // identical across workers.
             // Redis only has 16 logical databases, so wrap.
-            db: env.int("JEST_WORKER_ID", 0) % 16,
+            //
+            // REDIS_DB overrides it for the benchmark harness, which runs no
+            // jest workers and so put every scenario on db 0. Redis outlives
+            // the server process, unlike the in-process memory provider, so
+            // the ETag-off scenario left entries stored without an ETag that
+            // the later conditional-request scenario read straight back:
+            //   expected an ETag ... - is enableEtag on for this scenario?
+            // It also meant redis started each scenario warm while memory
+            // started cold, which is not a comparison worth publishing.
+            db: env.int("REDIS_DB", env.int("JEST_WORKER_ID", 0)) % 16,
           },
           settings: {
             debug: false,

--- a/scripts/benchmark.mjs
+++ b/scripts/benchmark.mjs
@@ -178,11 +178,19 @@ async function currentEtag(url) {
   return etag;
 }
 
-async function benchmarkScenario(scenario, args) {
+async function benchmarkScenario(scenario, args, index) {
   const url = `http://127.0.0.1:${args.port}${args.path}`;
 
   process.stdout.write(`\n[bench] ${scenario.name}\n`);
-  const server = await startServer(args.provider, scenario.env, args.port);
+  // Every scenario gets its own redis logical database, so each starts from a
+  // cold cache exactly like the in-process memory provider does. Sharing db 0
+  // let the ETag-off scenario's entries be read back by the conditional
+  // scenario, which then found no ETag on them and failed outright.
+  const server = await startServer(
+    args.provider,
+    { ...scenario.env, REDIS_DB: String(index) },
+    args.port
+  );
 
   try {
     await waitForServer(`http://127.0.0.1:${args.port}/_health`);
@@ -232,10 +240,16 @@ async function benchmarkScenario(scenario, args) {
     });
 
     // A scenario that silently stopped exercising what it claims to is worse
-    // than no scenario. 304s report as non-2xx, so check them explicitly.
-    if (scenario.expectStatus === 304 && result.non2xx === 0) {
+    // than no scenario. 304s report as non-2xx, so check them explicitly - and
+    // by status code, not by `non2xx`, which would also be satisfied by a run
+    // that returned nothing but 500s.
+    const expected = scenario.expectStatus
+      ? result.statusCodeStats?.[scenario.expectStatus]?.count ?? 0
+      : 0;
+
+    if (scenario.expectStatus && expected === 0) {
       throw new Error(
-        `${scenario.id}: expected 304 responses, saw none - the conditional request is not revalidating`
+        `${scenario.id}: expected ${scenario.expectStatus} responses, saw none - the conditional request is not revalidating`
       );
     }
 
@@ -247,6 +261,10 @@ async function benchmarkScenario(scenario, args) {
       throughput: result.throughput,
       errors: result.errors,
       non2xx: result.non2xx,
+      // Non-2xx responses that were NOT the status this scenario exists to
+      // produce. Everything downstream treats these as failures; the expected
+      // ones are not failures and must not be counted as such.
+      unexpectedNon2xx: result.non2xx - expected,
       timeouts: result.timeouts,
     };
   } finally {
@@ -305,13 +323,8 @@ function toMarkdown(results, args, meta) {
   );
   lines.push("");
 
-  const expectedNon2xx = new Set(
-    SCENARIOS.filter((s) => s.expectStatus === 304).map((s) => s.id)
-  );
   const unreliable = results.filter(
-    (r) =>
-      r.errors + r.timeouts > 0 ||
-      (r.non2xx > 0 && !expectedNon2xx.has(r.id))
+    (r) => r.errors + r.timeouts + r.unexpectedNon2xx > 0
   );
   if (unreliable.length) {
     const baselineFailed = unreliable.some((r) => r.id === "cache-disabled");
@@ -340,7 +353,11 @@ function toMarkdown(results, args, meta) {
   );
   lines.push("|---|---:|---:|---:|---:|---:|");
   for (const r of results) {
-    const failed = r.errors + r.timeouts + r.non2xx;
+    // A 304 is the successful outcome for the conditional scenario, and
+    // autocannon counts it as non-2xx. Counting it here reported every
+    // revalidation as a failure - "**2416** ⚠️" against the one scenario that
+    // did exactly what it was asked to - which reads as a broken benchmark.
+    const failed = r.errors + r.timeouts + r.unexpectedNon2xx;
     const speedup =
       baseline && r.id !== "cache-disabled" && baseline.requests.average > 0
         ? `${(r.requests.average / baseline.requests.average).toFixed(1)}x`
@@ -402,8 +419,8 @@ async function main() {
   };
 
   const results = [];
-  for (const scenario of SCENARIOS) {
-    results.push(await benchmarkScenario(scenario, args));
+  for (const [index, scenario] of SCENARIOS.entries()) {
+    results.push(await benchmarkScenario(scenario, args, index));
   }
 
   const markdown = toMarkdown(results, args, meta);
@@ -414,16 +431,13 @@ async function main() {
 
   // A conditional request answers 304, which autocannon counts as non-2xx.
   // Flagging it as a fault every run trains people to ignore the warning.
-  const expected304 = new Set(
-    SCENARIOS.filter((s) => s.expectStatus === 304).map((s) => s.id)
-  );
   const failed = results.filter(
-    (r) => r.errors || r.timeouts || (r.non2xx && !expected304.has(r.id))
+    (r) => r.errors || r.timeouts || r.unexpectedNon2xx
   );
   if (failed.length) {
     for (const r of failed) {
       process.stdout.write(
-        `\n[bench] WARNING: "${r.name}" had ${r.errors} errors, ${r.timeouts} timeouts, ${r.non2xx} non-2xx\n`
+        `\n[bench] WARNING: "${r.name}" had ${r.errors} errors, ${r.timeouts} timeouts, ${r.unexpectedNon2xx} unexpected non-2xx\n`
       );
     }
     if (failed.some((r) => r.id === "cache-disabled")) {


### PR DESCRIPTION
## The failure

The redis leg of [run 31759254171](https://github.com/strapi-community/plugin-rest-cache/actions/runs/31759254171) failed:

```
Error: expected an ETag from http://127.0.0.1:1337/api/homepage?populate=*
  - is enableEtag on for this scenario?
```

Note this is a *different* failure from the last run — the server booted fine,
so #197 did fix provider resolution. This is the harness.

## Cause

`playgrounds/redis/config/plugins.js` picks its logical database as:

```js
db: env.int("JEST_WORKER_ID", 0) % 16,
```

The benchmark runs no jest workers, so **every scenario shared db 0**. Unlike
the in-process memory provider, redis outlives the server process, so entries
written by `cache-no-etag` (ETag *off*) were still there when
`cache-conditional` started. It read one back, found no ETag on it, and aborted.

That is also why memory passed and redis didn't — memory dies with the process
and starts every scenario cold.

The secondary effect is worse than the crash: redis was starting each scenario
**warm** while memory started cold. Those two columns were never measuring the
same thing.

## Fix

`REDIS_DB` gives each scenario its own database, so redis matches memory's
cold start.

## Second bug, found while verifying

The summary table counted every 304 as a failure:

```
| Cache enabled, conditional requests (304) | 805 | 5 ms | 12 ms | **2416** | 3.3x ⚠️ |
```

2416 "failures" against the one scenario doing exactly what it was asked to.
The warning banner already excluded expected 304s; the table didn't. A
published `BENCHMARKS.md` with that row reads as a broken benchmark.

Both now derive from one `unexpectedNon2xx` value. Crucially it is computed
**by status code**, not by scenario id — the id-based skip would have silently
hidden a genuine 5xx in that scenario. For the same reason the guard now checks
`statusCodeStats[304]` instead of `non2xx`, which a run returning nothing but
500s would also have satisfied.

## Verified

Against a local redis, both providers, all five scenarios:

```
| Cache disabled (reference)                   | 246 | 16 ms | 45 ms | 0 | -    |
| Cache enabled, ETag off                      | 860 |  5 ms | 11 ms | 0 | 3.5x |
| Cache enabled, ETag on                       | 803 |  5 ms | 11 ms | 0 | 3.3x |
| Cache enabled, conditional requests (304)    | 767 |  6 ms | 13 ms | 0 | 3.1x |
| Cache enabled, every request a distinct key  | 437 |  8 ms | 48 ms | 0 | 1.8x |
```

`exit=0`, no warning banner, no failure counts.

And the guard was seen red on purpose — replacing the matching `If-None-Match`
with a wrong value reproduces:

```
Error: cache-conditional: expected 304 responses, saw none - the conditional request is not revalidating
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)