### PR TITLE
fix(publish): pass the tarball as a path, and make the label one-shot

### DIFF
--- a/.claude/skills/cut-a-release/SKILL.md
+++ b/.claude/skills/cut-a-release/SKILL.md
@@ -47,9 +47,14 @@ Users install with `npm install @strapi-community/plugin-rest-cache@next`.
 ## Experimental build from a pull request
 
 The easy path. Add the **`publish-experimental`** label to a pull request. It
-publishes `0.0.0-experimental.<pr head sha>` to the `experimental` dist-tag,
-republishes on every subsequent push to that PR, and keeps a comment on the PR
-with the exact install command.
+publishes `0.0.0-experimental.<pr head sha>` to the `experimental` dist-tag and
+comments on the PR with the exact install command.
+
+The workflow then **removes the label again**, including when the publish
+failed. The label is a one-shot request, not a mode: to cut another build after
+pushing more commits, add it back. It deliberately no longer fires on
+`synchronize`, which used to republish silently on every push for as long as
+the label happened to still be attached.
 
 Same-repo pull requests only; a fork PR never reaches the publish job.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,8 +35,14 @@ on:
   release:
     types: [published]
 
-  # Label a pull request `publish-experimental` and it publishes an
-  # experimental build, republishing on every push to that PR.
+  # Label a pull request `publish-experimental` and it publishes one
+  # experimental build, then removes the label again.
+  #
+  # The label is a one-shot request, not a mode the PR sits in. It used to also
+  # fire on `synchronize`, so every subsequent push republished silently for as
+  # long as the label happened to still be there. Taking the label off at the
+  # end of the run means each publish is a deliberate act: to cut another
+  # build, add the label again.
   #
   # `pull_request_target`, not `pull_request`, and the difference is the whole
   # security argument: `pull_request` would run the *PR branch's* copy of this
@@ -48,7 +54,7 @@ on:
   # job that holds secrets - does not apply, because the build job below holds
   # neither secrets nor an id-token.
   pull_request_target:
-    types: [labeled, synchronize]
+    types: [labeled]
 
   workflow_dispatch:
     inputs:
@@ -269,9 +275,16 @@ jobs:
           # No NODE_AUTH_TOKEN: authentication is OIDC via trusted publishing,
           # and provenance is generated automatically. publishConfig in each
           # package.json also sets provenance, as insurance.
+          # "./$tgz", never "$tgz". npm parses a bare relative path containing a
+          # slash as a GitHub shorthand - `owner/repo` - so `artifacts/x.tgz`
+          # sent it looking for a git remote instead of reading the tarball:
+          #   npm error command git ls-remote ssh://git@github.com/artifacts/x.tgz.git
+          #   npm error git@github.com: Permission denied (publickey).
+          # which reads like an auth failure and is nothing of the sort. A
+          # leading ./ is what makes it unambiguously a path.
           for tgz in artifacts/*.tgz; do
             echo "publishing $(basename "$tgz") to @$DIST_TAG"
-            npm publish "$tgz" --tag "$DIST_TAG"
+            npm publish "./$tgz" --tag "$DIST_TAG"
           done
 
       # Tells the PR author how to install what was just published. The
@@ -301,6 +314,8 @@ jobs:
               '```',
               '',
               'Install by exact version. The `experimental` tag moves with every build.',
+              '',
+              'The `publish-experimental` label has been removed. Add it again to publish another build.',
             ].join('\n');
 
             const { owner, repo } = context.repo;
@@ -327,3 +342,38 @@ jobs:
             echo
             echo 'Verify with `npm audit signatures` after installing.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Takes the trigger label back off, so the label always means "publish an
+  # experimental build now" rather than "this PR is in experimental mode".
+  #
+  # A separate job on purpose. It needs `pull-requests: write`, and the build
+  # job - the one that may run unreviewed code - must keep `contents: read` and
+  # nothing else. This job runs no checkout and no branch code, only this file
+  # from the default branch.
+  #
+  # `always()`: a failed publish must not leave the label behind, or the next
+  # person to add it sees nothing happen because it is already there.
+  unlabel:
+    name: Remove the trigger label
+    needs: [build, publish]
+    if: always() && github.event_name == 'pull_request_target' && needs.build.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'publish-experimental',
+              });
+            } catch (error) {
+              // 404 means someone already took it off. That is the desired
+              // end state, so it is not a failure.
+              if (error.status !== 404) throw error;
+            }


### PR DESCRIPTION
## The experimental publish failed — and not on auth

[Run 31760869448](https://github.com/strapi-community/plugin-rest-cache/actions/runs/31760869448). `Build and pack` succeeded; `Publish to npm` died:

```
npm error code 128
npm error An unknown git error occurred
npm error command git --no-replace-objects ls-remote \
  ssh://git@github.com/artifacts/strapi-community-plugin-rest-cache-0.0.0-experimental.ff1018e….tgz.git
npm error git@github.com: Permission denied (publickey).
```

That looks like an OIDC/trusted-publishing failure. It isn't — npm never
contacted the registry. It parses a **bare relative path containing a slash as
a GitHub shorthand** (`owner/repo`), so `artifacts/x.tgz` sent it looking for a
git remote instead of reading the tarball.

**This would have broken the 5.1.0 release in exactly the same way.** Finding
it is precisely what the experimental dry run was for.

### Reproduced and fixed locally, with `--dry-run`

```
$ npm publish --dry-run artifacts/…-memory-5.0.0.tgz
npm error command git ls-remote ssh://git@github.com/artifacts/…tgz.git   ← identical

$ npm publish --dry-run ./artifacts/…-memory-5.0.0.tgz
npm notice name: @strapi-community/provider-rest-cache-memory
npm notice filename: strapi-community-provider-rest-cache-memory-5.0.0.tgz
npm error You cannot publish over the previously published versions: 5.0.0.   ← reached the registry
```

The leading `./` is what makes it unambiguously a path.

## Second change: the label is now one-shot

Per @derrickmehaffy — the run now **removes `publish-experimental` when it
finishes**, so the label means "publish a build now" rather than "this PR is in
experimental mode". To cut another build after pushing, add it back.

`synchronize` is dropped from the trigger. It was the mechanism that made every
subsequent push republish silently for as long as the label happened to still
be attached; with the label removed after each run it would only ever fire in
the window before cleanup.

Three details worth reviewing:

- **`unlabel` is a separate job.** It needs `pull-requests: write`, and the
  `build` job — the one that may execute unreviewed branch code — must keep
  `contents: read` and nothing else. `unlabel` checks out nothing and runs only
  this file, from the default branch.
- **`always()`**, so a *failed* publish still clears the label. Otherwise the
  next person to add it sees nothing happen, because it is already there.
- A 404 from `removeLabel` is swallowed — someone removing it by hand produces
  the desired end state, not a failure.

The PR comment and `.claude/skills/cut-a-release/SKILL.md` both promised
republish-on-push, so both are updated.

## Note

Touches `.github/workflows/publish.yml`, so it needs a maintainer to merge.

And because `pull_request_target` runs the workflow from the **default
branch**, this fix has no effect until it is on `main` — re-labelling #201
before then will fail the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)