### PR TITLE
fix(release): run the deduper from a path that survives the checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -86,18 +86,29 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Copied out of the working tree before anything is checked out. The
+          # release branch is cut from whatever main was when release-please
+          # first opened the pull request, so it does not necessarily contain
+          # this script - the first run failed with MODULE_NOT_FOUND on the
+          # script's own path, immediately after checking out that branch.
+          SCRIPT="$RUNNER_TEMP/dedupe-changelog.mjs"
+          cp scripts/dedupe-changelog.mjs "$SCRIPT"
+
           # 1. The rolling release pull request.
           if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
             git fetch --quiet origin "$RELEASE_BRANCH"
             git checkout --quiet "$RELEASE_BRANCH"
-            node scripts/dedupe-changelog.mjs CHANGELOG.md
+            node "$SCRIPT" CHANGELOG.md
             if ! git diff --quiet -- CHANGELOG.md; then
               git config user.name "github-actions[bot]"
               git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
               git commit -q -m "chore: drop duplicate changelog entries" -- CHANGELOG.md
               git push origin "$RELEASE_BRANCH"
             fi
-            git checkout --quiet -
+            # Deliberately does not switch back. `git checkout -` aborts if
+            # CHANGELOG.md is still dirty, and nothing below needs the working
+            # tree - step 2 runs entirely through the API, with the script
+            # already copied out to $RUNNER_TEMP.
           fi
 
           # 2. Any draft release. Its notes are stored separately from
@@ -108,6 +119,6 @@ jobs:
           for tag in $(gh release list --limit 20 --json tagName,isDraft \
                         --jq '.[] | select(.isDraft) | .tagName'); do
             gh release view "$tag" --json body --jq .body > "$notes"
-            node scripts/dedupe-changelog.mjs "$notes"
+            node "$SCRIPT" "$notes"
             gh release edit "$tag" --notes-file "$notes"
           done


### PR DESCRIPTION
#210's step failed on its first real run — the wiring I flagged as untested.

```
Error: Cannot find module '/home/runner/work/plugin-rest-cache/plugin-rest-cache/scripts/dedupe-changelog.mjs'
```

It checks out the release branch, and that branch was cut from `3498f3a` —
**before** the script existed. So it checked out a tree without its own script
in it.

Fix: copy the script to `$RUNNER_TEMP` before touching the working tree.

## A second bug, found by rehearsing properly

Rather than ship untested wiring twice, I replayed the step verbatim against the
real `release-please--branches--main`. That surfaced a failure the first run
never got far enough to hit:

```
error: Your local changes to the following files would be overwritten by checkout:
	CHANGELOG.md
Aborting
```

`git checkout -` aborts while `CHANGELOG.md` is dirty. It was only switching
back out of tidiness — step 2 runs entirely through the API with the script
already copied out — so it no longer switches back.

## Verified

The step, run verbatim, against the actual release branch:

```
removed 11 duplicate entries:
  - add a cache statistics endpoint for the admin dashboard
  - add an opt-in content api purge endpoint
  ... (9 more)
committed OK: 85ec3c5 chore: drop duplicate changelog entries
step completed, exit=0
```

## Note

The failure was contained, as designed: it runs *after* release-please, so #209
was still updated correctly — only the deduplication was skipped. #209 currently
has 73 changelog entries; merging this drops it to 62.

Touches a workflow, so it needs a maintainer to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)