### PR TITLE
fix(admin): stop the settings table logging a React error on every render

### DIFF
--- a/packages/plugin-rest-cache/admin/src/components/ContentTypeTable/index.tsx
+++ b/packages/plugin-rest-cache/admin/src/components/ContentTypeTable/index.tsx
@@ -138,12 +138,20 @@ const ContentTypeTable = ({ contentTypes, canPurge }: ContentTypeTableProps) => 
                             'Responses are cached separately for each authenticated caller.',
                         })}
                       >
-                        <Badge>
-                          {formatMessage({
-                            id: getTranslation('contentTypes.authKeyed'),
-                            defaultMessage: 'Keyed per caller',
-                          })}
-                        </Badge>
+                        {/* The span is load-bearing. Tooltip clones its child
+                            through Radix's Slot to attach a ref, and Badge is a
+                            plain function component, so React logs "Function
+                            components cannot be given refs ... Check the render
+                            method of SlotClone" as an *error* on every render of
+                            this page in a production build. */}
+                        <span>
+                          <Badge>
+                            {formatMessage({
+                              id: getTranslation('contentTypes.authKeyed'),
+                              defaultMessage: 'Keyed per caller',
+                            })}
+                          </Badge>
+                        </span>
                       </Tooltip>
                     ) : null}
                     {sharesAuthenticatedEntries ? (
@@ -155,20 +163,23 @@ const ContentTypeTable = ({ contentTypes, canPurge }: ContentTypeTableProps) => 
                         })}
                       >
                         {/* Themed, not a hardcoded hex: the badge has to stay
-                            legible in dark mode and in every locale. */}
-                        <Badge
-                          backgroundColor="danger100"
-                          textColor="danger600"
-                          borderColor="danger200"
-                        >
-                          <Flex gap={1} alignItems="center">
-                            <WarningCircle />
-                            {formatMessage({
-                              id: getTranslation('contentTypes.authRisk'),
-                              defaultMessage: 'Shared across callers',
-                            })}
-                          </Flex>
-                        </Badge>
+                            legible in dark mode and in every locale. Wrapped for
+                            the same ref reason as the badge above. */}
+                        <span>
+                          <Badge
+                            backgroundColor="danger100"
+                            textColor="danger600"
+                            borderColor="danger200"
+                          >
+                            <Flex gap={1} alignItems="center">
+                              <WarningCircle />
+                              {formatMessage({
+                                id: getTranslation('contentTypes.authRisk'),
+                                defaultMessage: 'Shared across callers',
+                              })}
+                            </Flex>
+                          </Badge>
+                        </span>
                       </Tooltip>
                     ) : null}
                   </Flex>


### PR DESCRIPTION
Found by installing the published `5.1.0-beta` packages from npm into a real
Strapi app — [LaunchPad](https://github.com/strapi/LaunchPad) bumped to 5.52.0 —
and opening the settings page in a **production build**.

Every render logged, at `console.error`:

```
Warning: Function components cannot be given refs. Attempts to access this ref
will fail. Did you mean to use React.forwardRef()?
Check the render method of `SlotClone`.
  ...
  at td
  at F (http://127.0.0.1:1340/admin/index-CLIwyG7S-ChRqmRx_.js:1:712)   ← our chunk
```

`Tooltip` clones its child through Radix's `Slot` to attach a ref, and `Badge`
is a plain function component, so the ref lands nowhere.

It is only a warning in React's eyes, but it is emitted at `console.error` — so
anyone who opens devtools on this page sees the plugin throwing errors, and any
*real* error is buried under it.

## Fix

Wrap each `Badge` in a `span`, giving `Slot` a DOM node to hold. Tooltips and
badges render exactly as before.

## Verified in the same app

| | before | after |
| --- | --- | --- |
| console errors on the settings page | **1** | **0** |
| "Keyed per caller" badge renders | yes | yes |

Confirmed against both the memory and redis providers, by rebuilding the plugin,
packing it, installing the tarball into that app and rebuilding its admin — not
in `strapi develop`, which would not have shown it.

The login page and the admin homepage were at 0 errors throughout, which is what
narrowed it to our table in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)