### PR TITLE
chore: release stable by default, publish betas on demand

### DIFF
--- a/.claude/skills/cut-a-release/SKILL.md
+++ b/.claude/skills/cut-a-release/SKILL.md
@@ -38,11 +38,33 @@ npm.
 
 ## Pre-release
 
-Same flow, but mark the GitHub Release as a pre-release before publishing it.
-`publish.yml` reads `github.event.release.prerelease` and switches to the
-`next` dist-tag and the `npm-prerelease` environment.
+release-please only ever proposes **stable** versions. A beta is not something
+it produces, and there is deliberately no prerelease mode in its config - that
+made every ordinary release a beta and left the repository unable to reach a
+stable version without a `Release-As:` override.
 
-Users install with `npm install @strapi-community/plugin-rest-cache@next`.
+So a beta is a manual dispatch. Run the **publish** workflow from the Actions
+tab, with the branch selector on **main**:
+
+- `mode`: `next`
+- `version`: the exact version, e.g. `5.2.0-beta.0`
+- `target_branch`: the branch to build, defaults to `main`
+
+It stamps that version across all three packages, builds, and publishes to the
+`next` dist-tag through the `npm-prerelease` environment. Users install it with
+`npm install @strapi-community/plugin-rest-cache@next`.
+
+`version` must carry a prerelease suffix. `scripts/stamp-version.mjs` refuses a
+stable version, so no dispatch can put one on npm - stable versions come only
+from release-please and the version already committed to `package.json`.
+
+Nothing is tagged and no GitHub Release is created: a dispatched beta is a
+build of a branch, not a point in the release history. The run summary records
+the commit.
+
+If a GitHub Release is marked as a pre-release and published, that also routes
+to `next` - `publish.yml` reads `github.event.release.prerelease`. That path
+publishes the version release-please committed, and never stamps over it.
 
 ## Experimental build from a pull request
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,8 +61,12 @@ on:
         type: choice
         options: [latest, next, experimental]
         default: experimental
+      version:
+        description: "Prerelease version for mode=next, e.g. 5.2.0-beta.0"
+        type: string
+        required: false
       target_branch:
-        description: Branch to build (experimental mode only)
+        description: Branch to build (next and experimental modes)
         type: string
         required: false
       sha:
@@ -103,6 +107,7 @@ jobs:
           TARGET_BRANCH: ${{ github.event.inputs.target_branch }}
           INPUT_SHA: ${{ github.event.inputs.sha }}
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
           set -euo pipefail
 
@@ -114,6 +119,32 @@ jobs:
               mode="$INPUT_MODE"
               ;;
           esac
+
+          # A manually dispatched prerelease. release-please only ever proposes
+          # stable versions, so a beta is not something it can produce - the
+          # version is given here and stamped over what is committed.
+          #
+          # Refused for a `release` event: that path publishes the version
+          # release-please already wrote into package.json and tagged, and
+          # stamping something else over it would put a version on npm that no
+          # tag points at.
+          if [ "$mode" = "next" ] && [ "$EVENT" = "workflow_dispatch" ]; then
+            if ! printf '%s' "$INPUT_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z.-]+$'; then
+              echo "::error::mode=next requires a prerelease version such as 5.2.0-beta.0"
+              exit 1
+            fi
+            echo "stamp_version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+
+            # Same validation as the experimental path below.
+            if ! printf '%s' "${TARGET_BRANCH:-main}" | grep -Eq '^[A-Za-z0-9._/-]{1,200}$'; then
+              echo "::error::target_branch has unexpected characters"
+              exit 1
+            fi
+            case "${TARGET_BRANCH:-main}" in
+              -*|*..*) echo "::error::target_branch rejected"; exit 1 ;;
+            esac
+            echo "ref=${TARGET_BRANCH:-main}" >> "$GITHUB_OUTPUT"
+          fi
 
           if [ "$mode" = "experimental" ]; then
             # `sha` wins when both are given: experimental-dispatch.yml sends
@@ -151,12 +182,14 @@ jobs:
             echo "dist_tag=$mode"
           } >> "$GITHUB_OUTPUT"
 
+      # A release event checks out the tagged commit; anything with an explicit
+      # ref (experimental, or a manually dispatched prerelease) checks that out.
       - name: Check out the release commit
-        if: steps.plan.outputs.mode != 'experimental'
+        if: steps.plan.outputs.ref == ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check out the code under test
-        if: steps.plan.outputs.mode == 'experimental'
+        if: steps.plan.outputs.ref != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ steps.plan.outputs.ref }}
@@ -184,7 +217,16 @@ jobs:
           # never built.
           SHA="$(git rev-parse HEAD)"
           echo "building $SHA"
-          SHA="$SHA" node scripts/stamp-experimental-version.mjs
+          SHA="$SHA" node scripts/stamp-version.mjs
+
+      # Only for a manual dispatch. A prerelease published from a GitHub Release
+      # already carries release-please's version, and stamp_version is empty
+      # there, so this step does not run.
+      - name: Stamp the prerelease version
+        if: steps.plan.outputs.stamp_version != ''
+        env:
+          VERSION: ${{ steps.plan.outputs.stamp_version }}
+        run: node scripts/stamp-version.mjs
 
       - name: Build
         run: pnpm run build

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "separate-pull-requests": false,
   "pull-request-title-pattern": "chore: release ${version}",
   "draft": true,
   "changelog-sections": [
@@ -69,10 +68,7 @@
           "path": "packages/provider-rest-cache-redis/package.json",
           "jsonpath": "$.version"
         }
-      ],
-      "prerelease": true,
-      "prerelease-type": "beta",
-      "versioning": "prerelease"
+      ]
     }
   },
   "last-release-sha": "6407e61f4c89863c84e542bc2a92a07801ff4f9a"

--- a/scripts/stamp-version.mjs
+++ b/scripts/stamp-version.mjs
@@ -1,8 +1,17 @@
 #!/usr/bin/env node
 /**
- * Stamp every publishable package with an experimental version.
+ * Stamp every publishable package with a prerelease version.
  *
- * Version scheme: `0.0.0-experimental.<40-char sha>`.
+ * Two callers, both in publish.yml:
+ *
+ *   SHA=<40 hex>          an experimental build, stamped
+ *                         `0.0.0-experimental.<sha>`
+ *   VERSION=5.2.0-beta.0  a manually dispatched prerelease
+ *
+ * VERSION must carry a prerelease suffix. This script can therefore never
+ * stamp a stable version, so no manual dispatch can fabricate one - stable
+ * versions come only from release-please and the version already committed to
+ * package.json.
  *
  * The `0.0.0-` prefix is what actually protects users, not the dist-tag.
  * `^5.1.0` desugars to `>=5.1.0 <6.0.0`, and a major of 0 fails that lower
@@ -29,13 +38,27 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PACKAGES = join(ROOT, 'packages');
 
 const sha = process.env.SHA ?? '';
+const explicit = process.env.VERSION ?? '';
 
-if (!/^[0-9a-f]{40}$/.test(sha)) {
-  console.error(`SHA must be a full 40-character commit sha, got: ${JSON.stringify(sha)}`);
-  process.exit(1);
+let version;
+
+if (explicit) {
+  // Must be a prerelease. `5.2.0` would be selected by every `^5.x` range the
+  // moment it is published, with no review behind it.
+  if (!/^\d+\.\d+\.\d+-[0-9A-Za-z.-]+$/.test(explicit)) {
+    console.error(
+      `VERSION must be a prerelease such as 5.2.0-beta.0, got: ${JSON.stringify(explicit)}`
+    );
+    process.exit(1);
+  }
+  version = explicit;
+} else {
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    console.error(`SHA must be a full 40-character commit sha, got: ${JSON.stringify(sha)}`);
+    process.exit(1);
+  }
+  version = `0.0.0-experimental.${sha}`;
 }
-
-const version = `0.0.0-experimental.${sha}`;
 
 const manifests = readdirSync(PACKAGES)
   .map((name) => join(PACKAGES, name, 'package.json'))


### PR DESCRIPTION
Inverts the release model, and fixes the bug that made me hand-create the
`v5.1.0-beta` draft.

## Betas become manual

release-please was configured with prerelease versioning, so **every** release
it proposed was a beta, and the repo could not reach a stable version without a
`Release-As:` override. Betas are occasional and deliberate; stable is the
normal case.

Now: release-please proposes **stable versions only**. A beta is a dispatch of
`publish.yml`:

- `mode`: `next`
- `version`: `5.2.0-beta.0`
- `target_branch`: defaults to `main`

It stamps that version across all three packages and publishes to `next` via
`npm-prerelease`. Publishing stays inside `publish.yml` because npm's trusted
publishing validates the **workflow filename** — a second publishing workflow
could not authenticate.

`version` must carry a prerelease suffix; `stamp-version.mjs` refuses a stable
one, so **no dispatch can put a stable version on npm**. Those come only from
release-please and what is committed to `package.json`. A `release` event never
stamps — it publishes the version release-please already wrote and tagged.

## The real cause of the manual draft

`separate-pull-requests: false`. From `manifest.js:83`:

```js
this.separatePullRequests = manifestOptions?.separatePullRequests
  ?? (Object.keys(repositoryConfig).length === 1);
```

It defaults to `true` for a single package. Forcing it `false` kept the **merge
plugin** active, and `merge.js:81` hardcodes the branch to
`BranchName.ofTargetBranch(targetBranch)` — **no component** — while the
strategy's `getBranchComponent()` still returned `monorepo`. `buildRelease`
compares those two and aborted:

```
✔ Pull request contains releases, but not for component:
⚠ There are untagged, merged release PRs outstanding - aborting
```

It made sense with three packages. With one it is actively harmful. Removed.

Dry run confirms the branch now carries the component, so the comparison
matches — and the bare title is fixed as a side effect:

```
component:                                                        (empty → componentless body)
branch:  release-please--branches--…--components--monorepo        (component present)
title:   chore: release 5.1.0-beta.1                              (${version} interpolates)
```

## Verified

The plan step run directly over every mode:

| case | result |
| --- | --- |
| release, stable | `mode=latest dist_tag=latest` |
| release, prerelease | `mode=next dist_tag=next` (no stamping) |
| dispatch `next` + version | `stamp_version=5.2.0-beta.0 ref=main` |
| dispatch `next`, no version | **refused** |
| dispatch `next`, `5.2.0` | **refused** |
| dispatch experimental + branch / + sha | correct ref |
| dispatch `latest` | `mode=latest`, no ref |
| `../evil` and `--upload-pack=x` branches | **rejected** |

And the stamper directly: SHA path, explicit prerelease path, and a stable
`VERSION` refused.

## After this merges

The next release PR should read **`chore: release 5.1.0`** and, when merged,
release-please should create the draft **by itself** — that is the thing to
watch, since it is what failed before.

Release-As: 5.1.0