### PR TITLE
chore: graduate to a stable release

### DIFF
--- a/.claude/skills/cut-a-release/SKILL.md
+++ b/.claude/skills/cut-a-release/SKILL.md
@@ -66,6 +66,28 @@ If a GitHub Release is marked as a pre-release and published, that also routes
 to `next` - `publish.yml` reads `github.event.release.prerelease`. That path
 publishes the version release-please committed, and never stamps over it.
 
+## Moving off a prerelease version
+
+If the last release was a prerelease, release-please will not graduate on its
+own. The default versioning strategy keeps the suffix, so `5.1.0-beta` plus a
+`fix:` becomes `5.1.1-beta`, not `5.1.0`.
+
+Land a commit on `main` whose message carries the version as a footer:
+
+```
+chore: graduate to a stable release
+
+Release-As: 5.1.0
+```
+
+It applies to that one release and leaves nothing behind in the config.
+
+Note **where** the footer has to be. GitHub builds a squash commit from the
+pull request title and body only when the branch has more than one commit; with
+a single commit it uses that commit's own message. A footer written in the pull
+request description is silently dropped in that case, and the next release
+comes out as another prerelease.
+
 ## Experimental build from a pull request
 
 The easy path. Add the **`publish-experimental`** label to a pull request. It


### PR DESCRIPTION
The open release PR proposes **`5.1.1-beta`**, not `5.1.0`.

release-please does not graduate off a prerelease on its own — the default
versioning strategy keeps the suffix, so `5.1.0-beta` plus a `fix:` becomes
`5.1.1-beta`.

`Release-As:` in the commit message fixes it for that one release, and leaves
nothing behind in the config (unlike the `release-as` config key, which would
pin every subsequent release to the same version).

## Why it needs its own commit

I put the footer in #216's **pull request body** and it was dropped. GitHub only
builds a squash commit from the title and body when the branch has more than one
commit; with a single commit it uses that commit's own message.

So here the footer is in the commit message itself. **This PR must keep a single
commit** for that to survive — if it grows a second, the squash message comes
from this description instead, which also carries the footer, so either way it
lands.

That trap is now written into the release skill.

## Answering the question directly

**No, this is not needed again.** It exists only to cross from `5.1.0-beta` to
`5.1.0`. Once the manifest holds a stable version, release-please computes each
release from the conventional commits since the last one, and no footer is
involved.

## What to watch after merging

The release PR should flip to **`chore: release 5.1.0`**. Merging *that* is the
real test: release-please should create the draft **by itself**, which is what
`separate-pull-requests: false` was preventing.