### PR TITLE
fix(release): repair the 5.1.0 changelog, PR body and draft notes

### DIFF
--- a/scripts/consolidate-prerelease-changelog.mjs
+++ b/scripts/consolidate-prerelease-changelog.mjs
@@ -124,7 +124,13 @@ for (const section of sections.slice(0, 1)) {
     for (const group of splitSubsections(pre.body)) {
       const existing = groups.find((g) => g.name === group.name);
       if (existing) {
-        existing.entries = [...trimBlank(existing.entries), '', ...trimBlank(group.entries)];
+        // No separator between the two runs of entries. A blank line inside a
+        // markdown list ends it, so a separator here rendered every section as
+        // two lists with a gap down the middle instead of one list.
+        existing.entries = [
+          ...trimBlank(existing.entries).filter((line) => line.trim() !== ''),
+          ...trimBlank(group.entries).filter((line) => line.trim() !== ''),
+        ];
       } else {
         groups.push({ name: group.name, entries: trimBlank(group.entries) });
       }


### PR DESCRIPTION
#219 broke the changelog in #217. Every section renders as two lists with a gap
down the middle:

```
### Bug Fixes

* **admin:** stop the settings table logging a React error on every render (#215)
* **release:** fold the beta changelog into the release that supersedes it (#219)
                          ← blank line ends the list
* **admin:** make the panel work in a production build, and test it (#184)
* await the cache purge instead of deferring it to onCommit
```

The consolidation joined the two runs of entries with a separator:

```js
existing.entries = [...trimBlank(existing.entries), '', ...trimBlank(group.entries)];
```

A blank line inside a markdown list ends it. Removed, and both runs are stripped
of blank lines before joining.

## I said that change was verified. It wasn't.

I checked entry counts (36 = 3 + 33), heading order, and the maximum run of
consecutive blank lines. **None of those can see a single blank line between two
list items** — the count is right, the order is right, and the run length is 1.

The check that finds it looks for exactly that shape, and now runs against the
output:

```
=== blank line between two '* ' entries ===
  line 234  ← 4.0.0-alpha.0, present in the input, deliberately untouched
```

Zero new splits; the 5.1.0 section is one contiguous list per subsection:

```
### Features
* add a cache statistics endpoint for the admin dashboard
* add an opt-in content API purge endpoint
* **admin:** rewrite the admin panel in TypeScript and add a dashboard (#181)
…
```

## The already-broken branch

release-please regenerates `CHANGELOG.md` on the release branch from `main` on
each run, so once this lands the next run rebuilds it and the fixed fold applies.
I will confirm that on #217 rather than assume it — and if the branch does not
regenerate, deleting it makes release-please recreate it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)