### PR TITLE
fix(release): rebuild the release PR body and draft notes from the changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -92,8 +92,10 @@ jobs:
           # script's own path, immediately after checking out that branch.
           DEDUPE="$RUNNER_TEMP/dedupe-changelog.mjs"
           FOLD="$RUNNER_TEMP/consolidate-prerelease-changelog.mjs"
+          EXTRACT="$RUNNER_TEMP/extract-release-notes.mjs"
           cp scripts/dedupe-changelog.mjs "$DEDUPE"
           cp scripts/consolidate-prerelease-changelog.mjs "$FOLD"
+          cp scripts/extract-release-notes.mjs "$EXTRACT"
 
           # Asked for rather than hardcoded. The branch name depends on the
           # strategy's component, so it changed from
@@ -101,7 +103,9 @@ jobs:
           # `release-please--branches--main--components--monorepo` when
           # `separate-pull-requests: false` was removed - and a hardcoded name
           # does not fail, it silently skips, leaving the changelog untidied.
-          RELEASE_BRANCH=$(gh pr list --state open --json headRefName \
+          RELEASE_PR=$(gh pr list --state open --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')
+          RELEASE_BRANCH=$(gh pr list --state open --json number,headRefName \
             --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].headRefName // empty')
 
           # 1. The rolling release pull request.
@@ -120,20 +124,46 @@ jobs:
               git commit -q -m "chore: tidy the release changelog" -- CHANGELOG.md
               git push origin "$RELEASE_BRANCH"
             fi
+            # 2. The pull request body. release-please writes it from the
+            #    commits since the *last* release, so once a prerelease is
+            #    folded into the changelog the body still lists only what came
+            #    after that prerelease - 4 entries against 38 for 5.1.0. The
+            #    body is what a reviewer reads, and github-release copies it
+            #    into the draft release, so it has to carry the whole release.
+            #
+            #    Only the text between release-please's `---` delimiters is
+            #    replaced. The structure around it is load-bearing:
+            #    github-release parses the body to find the release, and an
+            #    earlier hand-edit of it is why the 5.1.0-beta draft had to be
+            #    created by hand.
+            VERSION=$(node -p "require('./.release-please-manifest.json')['.']")
+            echo "release version: $VERSION"
+            body=$(mktemp)
+            gh pr view "$RELEASE_PR" --json body --jq .body > "$body"
+            node "$EXTRACT" CHANGELOG.md "$VERSION" --splice "$body"
+            gh pr edit "$RELEASE_PR" --body-file "$body"
+
             # Deliberately does not switch back. `git checkout -` aborts if
             # CHANGELOG.md is still dirty, and nothing below needs the working
-            # tree - step 2 runs entirely through the API, with the script
-            # already copied out to $RUNNER_TEMP.
+            # tree - it runs entirely through the API, with the scripts already
+            # copied out to $RUNNER_TEMP.
           fi
 
-          # 2. Any draft release. Its notes are stored separately from
-          #    CHANGELOG.md, so deduplicating one does not touch the other, and
-          #    the draft is what a maintainer actually reads before pressing
-          #    Publish.
+          # 3. Any draft release. Its notes are stored separately again, so
+          #    neither of the above touches it, and it is the last thing read
+          #    before pressing Publish.
           notes=$(mktemp)
           for tag in $(gh release list --limit 20 --json tagName,isDraft \
                         --jq '.[] | select(.isDraft) | .tagName'); do
-            gh release view "$tag" --json body --jq .body > "$notes"
-            node "$DEDUPE" "$notes"
+            version=${tag#v}
+            # Rebuild from the changelog when that release has a section there,
+            # so the draft matches what shipped. Otherwise deduplicate what
+            # release-please wrote.
+            if [ -n "$RELEASE_BRANCH" ] && node "$EXTRACT" CHANGELOG.md "$version" --body-only > "$notes" 2>/dev/null; then
+              echo "draft $tag: rebuilt from CHANGELOG.md"
+            else
+              gh release view "$tag" --json body --jq .body > "$notes"
+              node "$DEDUPE" "$notes"
+            fi
             gh release edit "$tag" --notes-file "$notes"
           done

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * Prints one release's section from CHANGELOG.md.
+ *
+ * CHANGELOG.md is the merged, deduplicated list once the release branch has
+ * been tidied. The release pull request body and the draft release notes are
+ * generated separately by release-please, from the commits since the *last*
+ * release - so after a prerelease is folded in they carry only the handful of
+ * commits since that prerelease, while the changelog carries the release.
+ *
+ * For 5.1.0 that was 4 entries in the pull request body against 38 in the
+ * changelog. The body and the draft are what people actually read, and
+ * github-release copies the body into the draft, so both are rebuilt from here.
+ *
+ * Usage:
+ *   node scripts/extract-release-notes.mjs CHANGELOG.md 5.1.0              # with heading
+ *   node scripts/extract-release-notes.mjs CHANGELOG.md 5.1.0 --body-only  # without
+ *   node scripts/extract-release-notes.mjs CHANGELOG.md 5.1.0 --splice body.md
+ *
+ * `--splice` rewrites a release pull request body in place, replacing what sits
+ * between release-please's `---` delimiters and leaving the rest byte for byte.
+ * That structure is not decoration: github-release parses the body to find the
+ * release, and an earlier hand-edit of it is why the 5.1.0-beta draft had to be
+ * created manually. The heading written here comes from CHANGELOG.md, which is
+ * the same shape release-please writes.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const [, , file, version, ...flags] = process.argv;
+if (!file || !version) {
+  console.error('usage: extract-release-notes.mjs <changelog> <version> [--body-only] [--splice <file>]');
+  process.exit(1);
+}
+
+const lines = readFileSync(file, 'utf8').split('\n');
+const HEADING = /^##\s+\[?(?<version>\d+\.\d+\.\d+[^\]\s)]*)\]?/;
+
+let start = -1;
+let end = lines.length;
+
+for (let i = 0; i < lines.length; i += 1) {
+  const match = lines[i].match(HEADING);
+  if (!match) continue;
+  if (start === -1 && match.groups.version === version) {
+    start = i;
+  } else if (start !== -1) {
+    end = i;
+    break;
+  }
+}
+
+if (start === -1) {
+  console.error(`no section for ${version} in ${file}`);
+  process.exit(1);
+}
+
+const section = lines.slice(flags.includes('--body-only') ? start + 1 : start, end);
+
+// Trim leading and trailing blank lines, leaving the interior untouched.
+while (section.length && section[0].trim() === '') section.shift();
+while (section.length && section[section.length - 1].trim() === '') section.pop();
+
+const notes = section.join('\n');
+
+const spliceIndex = flags.indexOf('--splice');
+if (spliceIndex === -1) {
+  process.stdout.write(`${notes}\n`);
+} else {
+  const bodyFile = flags[spliceIndex + 1];
+  if (!bodyFile) {
+    console.error('--splice needs a file');
+    process.exit(1);
+  }
+
+  const bodyLines = readFileSync(bodyFile, 'utf8').split('\n');
+  const first = bodyLines.indexOf('---');
+  const last = bodyLines.lastIndexOf('---');
+
+  if (first === -1 || last === first) {
+    console.error(`${bodyFile} does not look like a release pull request body`);
+    process.exit(1);
+  }
+
+  const rebuilt = [
+    ...bodyLines.slice(0, first + 1),
+    '',
+    '',
+    notes,
+    '',
+    ...bodyLines.slice(last),
+  ].join('\n');
+
+  writeFileSync(bodyFile, rebuilt);
+  console.error(`spliced ${(notes.match(/^\* /gm) || []).length} entries into ${bodyFile}`);
+}


### PR DESCRIPTION
You were right and I was looking at the wrong artifact.

**#217's pull request body lists 4 entries. Its changelog lists 38.**

```
### Bug Fixes
* **admin:** stop the settings table logging a React error on every render (#215)
* **release:** fold the beta changelog into the release that supersedes it (#219)
### Documentation
* backfill 4.2.9, 5.0.0 and 5.0.1 into the changelog (#213)
### Chores
* graduate to a stable release (#218)
```

## Why, and why it matters more than it looks

release-please generates the body from the commits since the **last** release —
and the last release was `5.1.0-beta`. So once the beta is folded into the
changelog, the body still describes only what came after it.

`github-release` then **copies that body into the draft release**. So the
published 5.1.0 release notes would have shipped with those 4 lines, omitting
the 33 changes that are the release. Folding the changelog fixed the file and
left both of the things people actually read.

## Fix

The body and the draft notes are rebuilt from `CHANGELOG.md`, which is the
merged and deduplicated list.

Only the text between release-please's `---` delimiters is replaced; the heading
comes from the changelog, which is the shape release-please writes. That
structure is load-bearing — `github-release` parses the body to find the
release, and an earlier hand-edit of it is exactly why the 5.1.0-beta draft had
to be created manually.

## Verified against the live #217 and its branch

```
version=5.1.0   changelog entries: 38
spliced 38 entries
  parses: true | version: 5.1.0 | component: undefined | entries: 38
  blank lines splitting a list in the new body: 0
```

The parse check runs release-please's own `PullRequestBody.parse` over the
rebuilt body — the check that would have caught the breakage that forced the
manual draft. Splicing twice leaves 38, so a re-run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)